### PR TITLE
Refactor: split app.py into store, hotkeys, and tray modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,15 +1,14 @@
-import os
 import csv
-import io
 import json
+import os
+import sys
 import threading
 import time
-import urllib.request
 import urllib.error
-import sys
+import urllib.request
 import uuid
-import platform
-from queue import Queue, Empty
+from queue import Empty, Queue
+
 from flask import (
     Flask,
     Response,
@@ -19,202 +18,33 @@ from flask import (
     stream_with_context,
 )
 
-
-try:
-    if platform.system() == "Darwin":
-        raise ImportError
-    from pynput import keyboard as pynput_keyboard
-
-    PYNPUT_AVAILABLE = True
-except:
-    PYNPUT_AVAILABLE = False
-    print("[hotkeys] pynput not available - hotkeys disabled")
-
-try:
-    import webview
-
-    WEBVIEW_AVAILABLE = True
-except ImportError:
-    WEBVIEW_AVAILABLE = False
-    print("[webview] pywebview not available - falling back to browser mode")
+import store
+import tray
+from hotkeys import PYNPUT_AVAILABLE, rebuild_hotkeys
+from store import (
+    GAME_POKEDEX_MAP,
+    GAMES_CACHE_DIR,
+    load_hunts,
+    load_settings,
+    save_hunts,
+    save_settings,
+    broadcast,
+    sse_clients,
+    sse_lock,
+)
+from tray import WEBVIEW_AVAILABLE, _on_closing, _setup_tray, _wait_for_server
 
 
 if getattr(sys, "frozen", False):
-    _BASE_DIR = os.path.dirname(sys.executable)
     _TEMPLATE_DIR = os.path.join(sys._MEIPASS, "templates")
     _STATIC_DIR = os.path.join(sys._MEIPASS, "static")
-
-    import certifi
-
-    os.environ["SSL_CERT_FILE"] = certifi.where()
-    os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
 else:
-    _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-    _TEMPLATE_DIR = os.path.join(_BASE_DIR, "templates")
-    _STATIC_DIR = os.path.join(_BASE_DIR, "static")
-
+    _TEMPLATE_DIR = os.path.join(store._BASE_DIR, "templates")
+    _STATIC_DIR = os.path.join(store._BASE_DIR, "static")
 
 app = Flask(__name__, template_folder=_TEMPLATE_DIR, static_folder=_STATIC_DIR)
 
-DATA_DIR = os.path.join(_BASE_DIR, "data")
-DATA_FILE = os.path.join(DATA_DIR, "hunts.json")
-SETTINGS_FILE = os.path.join(DATA_DIR, "settings.json")
-
-GAMES_CACHE_DIR = os.path.join(DATA_DIR, "game_cache")
-
-GAME_POKEDEX_MAP: dict[str, list[str]] = {
-    "Red / Blue": ["kanto"],
-    "Yellow": ["kanto"],
-    "Gold / Silver": ["original-johto"],
-    "Crystal": ["original-johto"],
-    "Ruby / Sapphire": ["hoenn"],
-    "FireRed / LeafGreen": ["kanto"],
-    "Emerald": ["hoenn"],
-    "Diamond / Pearl": ["original-sinnoh"],
-    "Platinum": ["extended-sinnoh"],
-    "HeartGold / SoulSilver": ["updated-johto"],
-    "Black / White": ["original-unova"],
-    "Black 2 / White 2": ["updated-unova"],
-    "X / Y": ["kalos-central", "kalos-coastal", "kalos-mountain"],
-    "Omega Ruby / Alpha Sapphire": ["updated-hoenn"],
-    "Sun / Moon": ["original-alola"],
-    "Ultra Sun / Ultra Moon": ["updated-alola"],
-    "Let's Go Pikachu / Eevee": ["letsgo-kanto"],
-    "Sword / Shield": ["galar", "isle-of-armor", "crown-tundra"],
-    "Brilliant Diamond / Shining Pearl": ["updated-sinnoh"],
-    "Legends: Arceus": ["hisui"],
-    "Scarlet / Violet": ["paldea", "kitakami", "blueberry"],
-    "Legends: Z-A": ["kalos-central", "kalos-coastal", "kalos-mountain"],
-}
-
-_game_pokemon_cache: dict[str, list[str]] = {}
-
-_webview_window = None
-_macos_tray_refs = {}
-
-_pokemon_list_cache = None
-
-_quitting = False
-
 _http_opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
-
-
-# SSE Client Registry
-sse_clients: list[Queue] = []
-sse_lock = threading.Lock()
-
-# Global hotkey listener
-hotkey_listener = None
-hotkey_lock = threading.Lock()
-
-
-# Data Helpers
-def load_hunts() -> list:
-    os.makedirs(DATA_DIR, exist_ok=True)
-    if not os.path.exists(DATA_FILE):
-        return []
-
-    try:
-        with open(DATA_FILE) as f:
-            return json.load(f)
-    except (json.JSONDecodeError, OSError):
-        return []
-
-
-def save_hunts(hunts: list) -> None:
-    os.makedirs(DATA_DIR, exist_ok=True)
-    with open(DATA_FILE, "w") as f:
-        json.dump(hunts, f, indent=2)
-
-
-def load_settings() -> dict:
-    defaults = {
-        "close_behavior": "ask",
-        "mark_found_behavior": "ask",
-    }
-    os.makedirs(DATA_DIR, exist_ok=True)
-    if not os.path.exists(SETTINGS_FILE):
-        return defaults
-    try:
-        with open(SETTINGS_FILE) as f:
-            saved = json.load(f)
-        return {**defaults, **saved}
-    except (json.JSONDecodeError, OSError):
-        return defaults
-
-
-def save_settings(settings: dict) -> None:
-    os.makedirs(DATA_DIR, exist_ok=True)
-    with open(SETTINGS_FILE, "w") as f:
-        json.dump(settings, f, indent=2)
-
-
-# SSE Broadcast
-def broadcast(hunts: list) -> None:
-    payload = json.dumps({"hunts": hunts})
-    with sse_lock:
-        for q in list(sse_clients):
-            try:
-                q.put_nowait(payload)
-            except Exception:
-                pass
-
-
-# Hotkeys
-def increment_hunt_by_id(hunt_id: str) -> None:
-    print(f"[hotkeys] Increment fired for {hunt_id}")
-    hunts = load_hunts()
-    for h in hunts:
-        if h["id"] == hunt_id:
-            h["count"] += 1
-            save_hunts(hunts)
-            broadcast(hunts)
-            return
-
-
-def decrement_hunt_by_id(hunt_id: str) -> None:
-    print(f"[hotkeys] Decrement fired for {hunt_id}")
-    hunts = load_hunts()
-    for h in hunts:
-        if h["id"] == hunt_id:
-            h["count"] = max(0, h["count"] - 1)
-            save_hunts(hunts)
-            broadcast(hunts)
-            return
-
-
-def rebuild_hotkeys() -> None:
-    global hotkey_listener
-    if not PYNPUT_AVAILABLE:
-        return
-    with hotkey_lock:
-        if hotkey_listener is not None:
-            try:
-                hotkey_listener.stop()
-            except Exception:
-                pass
-            hotkey_listener = None
-
-        hunts = load_hunts()
-        active_hunts = [h for h in hunts if h.get("status", "active") == "active"]
-        hotkey_map = {}
-        for h in active_hunts:
-            if h.get("hotkey"):
-                hotkey_map[h["hotkey"]] = lambda hid=h["id"]: increment_hunt_by_id(hid)
-            if h.get("hotkeyDecrement"):
-                hotkey_map[h["hotkeyDecrement"]] = lambda hid=h[
-                    "id"
-                ]: decrement_hunt_by_id(hid)
-        print(f"[hotkey] Registering: {list(hotkey_map.keys())}")
-        if not hotkey_map:
-            return
-        try:
-            listener = pynput_keyboard.GlobalHotKeys(hotkey_map)
-            listener.daemon = True
-            listener.start()
-            hotkey_listener = listener
-        except Exception as e:
-            print(f"[hotkeys] Failed to start listener: {e}")
 
 
 # Routes - Pages
@@ -484,8 +314,8 @@ def hammerspoon_config():
 @app.get("/api/pokemon-list")
 def pokemon_list():
     global _pokemon_list_cache
-    if _pokemon_list_cache is not None:
-        return jsonify(_pokemon_list_cache)
+    if store._pokemon_list_cache is not None:
+        return jsonify(store._pokemon_list_cache)
 
     try:
         req = urllib.request.Request(
@@ -506,8 +336,8 @@ def pokemon_list_by_game(game):
         return jsonify({"error": "Unknown game"}), 404
 
     # In memory cache hit
-    if game in _game_pokemon_cache:
-        return jsonify(_game_pokemon_cache[game])
+    if game in store._game_pokemon_cache:
+        return jsonify(store._game_pokemon_cache[game])
 
     # Disk cache hit (30 day expiry)
     os.makedirs(GAMES_CACHE_DIR, exist_ok=True)
@@ -519,7 +349,7 @@ def pokemon_list_by_game(game):
             with open(cache_file) as f:
                 cached = json.load(f)
             if time.time() - cached.get("ts", 0) < 86400 * 30:
-                _game_pokemon_cache[game] = cached["names"]
+                store._game_pokemon_cache[game] = cached["names"]
                 return jsonify(cached["names"])
         except (json.JSONDecodeError, OSError, KeyError):
             pass
@@ -549,7 +379,7 @@ def pokemon_list_by_game(game):
     except OSError:
         pass
 
-    _game_pokemon_cache[game] = result
+    store._game_pokemon_cache[game] = result
     return jsonify(result)
 
 
@@ -559,7 +389,7 @@ def refresh_game_cache(game):
         return jsonify({"error": "Unknown game"}), 404
 
     # Clear caches and re-fetch data
-    _game_pokemon_cache.pop(game, None)
+    store._game_pokemon_cache.pop(game, None)
     cache_file = os.path.join(
         GAMES_CACHE_DIR, f"{game.replace('/', '_').replace(' ', '_')}.json"
     )
@@ -658,145 +488,16 @@ def close_action():
     if action == "quit":
 
         def _quit():
-            global _quitting
             time.sleep(0.05)
-            _quitting = True
-            if _webview_window:
-                _webview_window.destroy()
+            tray._quitting = True
+            if tray._webview_window:
+                tray._webview_window.destroy()
 
         threading.Thread(target=_quit, daemon=True).start()
     elif action == "minimize":
-        if _webview_window:
-            _webview_window.hide()
+        if tray._webview_window:
+            tray._webview_window.hide()
     return jsonify({"ok": True})
-
-
-# Tray + WebView helpers
-def _make_tray_icon():
-    from PIL import Image, ImageDraw
-
-    img = Image.new("RGBA", (64, 64), (0, 0, 0, 0))
-    ImageDraw.Draw(img).ellipse([2, 2, 62, 62], fill=(114, 9, 183, 255))
-    return img
-
-
-def _setup_tray_pystray(window):
-    try:
-        import pystray
-
-        def _open(icon, item):
-            window.show()
-
-        def _quit(icon, item):
-            icon.stop()
-            os._exit(0)
-
-        icon = pystray.Icon(
-            "ShinyTrak",
-            _make_tray_icon(),
-            "ShinyTrak",
-            menu=pystray.Menu(
-                pystray.MenuItem("Open Shiny Trak", _open),
-                pystray.Menu.SEPARATOR,
-                pystray.MenuItem("Quit", _quit),
-            ),
-        )
-        icon.run_detached()
-    except ImportError:
-        pass
-
-
-def _create_macos_status_item(window):
-    try:
-        from AppKit import (
-            NSStatusBar,
-            NSMenu,
-            NSMenuItem,
-            NSVariableStatusItemLength,
-            NSObject,
-        )
-
-        class _MenuDelegate(NSObject):
-            def openApp_(self, sender):
-                window.show()
-
-            def quitApp_(self, sender):
-                os._exit(0)
-
-        delegate = _MenuDelegate.alloc().init()
-        bar = NSStatusBar.systemStatusBar()
-        status_item = bar.statusItemWithLength_(NSVariableStatusItemLength)
-        status_item.button().setTitle_("✨")
-
-        menu = NSMenu.alloc().init()
-        open_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Open Shiny Trak", "openApp:", ""
-        )
-        open_item.setTarget_(delegate)
-        sep = NSMenuItem.separatorItem()
-        quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Quit", "quitApp:", ""
-        )
-        quit_item.setTarget_(delegate)
-        for item in [open_item, sep, quit_item]:
-            menu.addItem_(item)
-        status_item.setMenu_(menu)
-
-        _macos_tray_refs["status_item"] = status_item
-        _macos_tray_refs["delegate"] = delegate
-        _macos_tray_refs["menu"] = menu
-    except Exception as e:
-        print(f"[tray] macOS status item failed: {e}")
-
-
-def _setup_tray(window):
-    if platform.system() == "Darwin":
-        import ctypes
-
-        _lib = ctypes.CDLL("/usr/lib/system/libdispatch.dylib")
-        _CB = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
-        _cb = _CB(lambda _: _create_macos_status_item(window))
-        _macos_tray_refs["_dispatch_cb"] = _cb
-        _lib.dispatch_async_f.argtypes = [ctypes.c_void_p, ctypes.c_void_p, _CB]
-        _lib.dispatch_async_f.restype = None
-        _main_q = ctypes.addressof(ctypes.c_char.in_dll(_lib, "_dispatch_main_q"))
-        _lib.dispatch_async_f(_main_q, None, _cb)
-    else:
-        _setup_tray_pystray(window)
-
-
-def _on_closing():
-    if not _webview_window:
-        return
-    if _quitting:
-        return
-    behavior = load_settings().get("close_behavior", "ask")
-    if behavior == "minimize":
-        _webview_window.hide()
-        return False
-    elif behavior == "ask":
-
-        def _dispatch():
-            time.sleep(0.1)
-            if _webview_window:
-                _webview_window.evaluate_js(
-                    "window.dispatchEvent(new CustomEvent('show-close-dialog'))"
-                )
-
-        threading.Thread(target=_dispatch, daemon=True).start()
-        return False
-
-
-def _wait_for_server(port=3000, timeout=10):
-    import socket
-
-    start = time.time()
-    while time.time() - start < timeout:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                return
-        except OSError:
-            time.sleep(0.05)
 
 
 # Start
@@ -812,7 +513,9 @@ if __name__ == "__main__":
     _wait_for_server()
 
     if WEBVIEW_AVAILABLE:
-        _webview_window = webview.create_window(
+        import webview
+
+        tray._webview_window = webview.create_window(
             "Shiny Trak",
             "http://localhost:3000",
             width=1100,
@@ -821,8 +524,8 @@ if __name__ == "__main__":
             text_select=False,
             background_color="#0D0B1A",
         )
-        _webview_window.events.closing += _on_closing
-        webview.start(func=_setup_tray, args=(_webview_window,))
+        tray._webview_window.events.closing += _on_closing
+        webview.start(func=_setup_tray, args=(tray._webview_window,))
         os._exit(0)
     else:
         print("Shiny Trak running at    http://localhost:3000")

--- a/hotkeys.py
+++ b/hotkeys.py
@@ -1,0 +1,74 @@
+import platform
+import threading
+
+from store import broadcast, load_hunts, save_hunts
+
+
+try:
+    if platform.system() == "Darwin":
+        raise ImportError
+    from pynput import keyboard as pynput_keyboard
+
+    PYNPUT_AVAILABLE = True
+except Exception:
+    PYNPUT_AVAILABLE = False
+    print("[hotkeys] pynput is not available - hotkeys disabled")
+
+hotkey_listener = None
+hotkey_lock = threading.Lock()
+
+
+def increment_hunt_by_id(hunt_id: str) -> None:
+    print(f"[hotkeys] Increment fired for {hunt_id}")
+    hunts = load_hunts()
+    for h in hunts:
+        if h["id"] == hunt_id:
+            h["count"] += 1
+            save_hunts(hunts)
+            broadcast(hunts)
+            return
+
+
+def decrement_hunt_by_id(hunt_id: str) -> None:
+    print(f"[hotkeys] Decrement fired for {hunt_id}")
+    hunts = load_hunts()
+    for h in hunts:
+        if h["id"] == hunt_id:
+            h["count"] = max(0, h["count"] - 1)
+            save_hunts(hunts)
+            broadcast(hunts)
+            return
+
+
+def rebuild_hotkeys() -> None:
+    global hotkey_listener
+    if not PYNPUT_AVAILABLE:
+        return
+    with hotkey_lock:
+        if hotkey_listener is not None:
+            try:
+                hotkey_listener.stop()
+            except Exception:
+                pass
+            hotkey_listener = None
+
+        hunts = load_hunts()
+        active_hunts = [h for h in hunts if h.get("status", "active") == "active"]
+        hotkey_map = {}
+        for h in active_hunts:
+            if h.get("hotkey"):
+                hotkey_map[h["hotkey"]] = lambda hid=h["id"]: increment_hunt_by_id(hid)
+            if h.get("hotkeyDecrement"):
+                hotkey_map[h["hotkeyDecrement"]] = lambda hid=h[
+                    "id"
+                ]: decrement_hunt_by_id(hid)
+        print(f"[hotkey] Registering: {list(hotkey_map.keys())}")
+        if not hotkey_map:
+            return
+        try:
+            listener = pynput_keyboard.GlobalHotKeys(hotkey_map)
+            listener.daemon = True
+            listener.start()
+            hotkey_listener = listener
+        except Exception as e:
+            print(f"[hotkeys] Failed to start listener: {e}")

--- a/store.py
+++ b/store.py
@@ -1,0 +1,103 @@
+import os
+import json
+import threading
+import time
+import sys
+from queue import Queue
+
+
+if getattr(sys, "frozen", False):
+    _BASE_DIR = os.path.dirname(sys.executable)
+
+    import certifi
+
+    os.environ["SSL_CERT_FILE"] = certifi.where()
+    os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
+else:
+    _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+DATA_DIR = os.path.join(_BASE_DIR, "data")
+DATA_FILE = os.path.join(DATA_DIR, "hunts.json")
+SETTINGS_FILE = os.path.join(DATA_DIR, "settings.json")
+GAMES_CACHE_DIR = os.path.join(DATA_DIR, "game_cache")
+
+GAME_POKEDEX_MAP: dict[str, list[str]] = {
+    "Red / Blue": ["kanto"],
+    "Yellow": ["kanto"],
+    "Gold / Silver": ["original-johto"],
+    "Crystal": ["original-johto"],
+    "Ruby / Sapphire": ["hoenn"],
+    "FireRed / LeafGreen": ["kanto"],
+    "Emerald": ["hoenn"],
+    "Diamond / Pearl": ["original-sinnoh"],
+    "Platinum": ["extended-sinnoh"],
+    "HeartGold / SoulSilver": ["updated-johto"],
+    "Black / White": ["original-unova"],
+    "Black 2 / White 2": ["updated-unova"],
+    "X / Y": ["kalos-central", "kalos-coastal", "kalos-mountain"],
+    "Omega Ruby / Alpha Sapphire": ["updated-hoenn"],
+    "Sun / Moon": ["original-alola"],
+    "Ultra Sun / Ultra Moon": ["updated-alola"],
+    "Let's Go Pikachu / Eevee": ["letsgo-kanto"],
+    "Sword / Shield": ["galar", "isle-of-armor", "crown-tundra"],
+    "Brilliant Diamond / Shining Pearl": ["updated-sinnoh"],
+    "Legends: Arceus": ["hisui"],
+    "Scarlet / Violet": ["paldea", "kitakami", "blueberry"],
+    "Legends: Z-A": ["kalos-central", "kalos-coastal", "kalos-mountain"],
+}
+
+_game_pokemon_cache: dict[str, list[str]] = {}
+_pokemon_list_cache = None
+
+# SSE Client Registry
+sse_clients: list[Queue] = []
+sse_lock = threading.Lock()
+
+
+def load_hunts() -> list:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    if not os.path.exists(DATA_FILE):
+        return []
+    try:
+        with open(DATA_FILE) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def save_hunts(hunts: list) -> None:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(DATA_FILE, "w") as f:
+        json.dump(hunts, f, indent=2)
+
+
+def load_settings() -> dict:
+    defaults = {
+        "close_behavior": "ask",
+        "mark_found_behavior": "ask",
+    }
+    os.makedirs(DATA_DIR, exist_ok=True)
+    if not os.path.exists(SETTINGS_FILE):
+        return defaults
+    try:
+        with open(SETTINGS_FILE) as f:
+            saved = json.load(f)
+        return {**defaults, **saved}
+    except (json.JSONDecodeError, OSError):
+        return defaults
+
+
+def save_settings(settings: dict) -> None:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(SETTINGS_FILE, "w") as f:
+        json.dump(settings, f, indent=2)
+
+
+def broadcast(hunts: list) -> None:
+    payload = json.dumps({"hunts": hunts})
+    with sse_lock:
+        for q in list(sse_clients):
+            try:
+                q.put_nowait(payload)
+            except Exception:
+                pass

--- a/tray.py
+++ b/tray.py
@@ -1,0 +1,145 @@
+import ctypes
+import os
+import platform
+import threading
+import time
+
+from store import load_settings
+
+
+try:
+    import webview
+
+    WEBVIEW_AVAILABLE = True
+except ImportError:
+    WEBVIEW_AVAILABLE = False
+    print("[webview] pywebview is not available - falling back to browser mode")
+
+_webview_window = None
+_macos_tray_refs = {}
+_quitting = False
+
+
+def _make_tray_icon():
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (64, 64), (0, 0, 0, 0))
+    ImageDraw.Draw(img).ellipse([2, 2, 62, 62], fill=(114, 9, 183, 255))
+    return img
+
+
+def _setup_tray_pystray(window):
+    try:
+        import pystray
+
+        def _open(icon, item):
+            window.show()
+
+        def _quit(icon, item):
+            icon.stop()
+            os._exit(0)
+
+        icon = pystray.Icon(
+            "ShinyTrak",
+            _make_tray_icon(),
+            "ShinyTrak",
+            menu=pystray.Menu(
+                pystray.MenuItem("Open Shiny Trak", _open),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Quit", _quit),
+            ),
+        )
+        icon.run_detached()
+    except ImportError:
+        pass
+
+
+def _create_macos_status_item(window):
+    try:
+        from AppKit import (
+            NSStatusBar,
+            NSMenu,
+            NSMenuItem,
+            NSVariableStatusItemLength,
+            NSObject,
+        )
+
+        class _MenuDelegate(NSObject):
+            def openApp_(self, sender):
+                window.show()
+
+            def quitApp_(self, sender):
+                os._exit(0)
+
+        delegate = _MenuDelegate.alloc().init()
+        bar = NSStatusBar.systemStatusBar()
+        status_item = bar.statusItemWithLength_(NSVariableStatusItemLength)
+        status_item.button().setTitle_("✨")
+
+        menu = NSMenu.alloc().init()
+        open_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Open Shiny Trak", "openApp:", ""
+        )
+        open_item.setTarget_(delegate)
+        sep = NSMenuItem.separatorItem()
+        quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Quit", "quitApp:", ""
+        )
+        quit_item.setTarget_(delegate)
+        for item in [open_item, sep, quit_item]:
+            menu.addItem_(item)
+        status_item.setMenu_(menu)
+
+        _macos_tray_refs["status_item"] = status_item
+        _macos_tray_refs["delegate"] = delegate
+        _macos_tray_refs["menu"] = menu
+    except Exception as e:
+        print(f"[tray] macOS status item failed: {e}")
+
+
+def _setup_tray(window):
+    if platform.system() == "Darwin":
+        _lib = ctypes.CDLL("/usr/lib/system/libdispatch.dylib")
+        _CB = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+        _cb = _CB(lambda _: _create_macos_status_item(window))
+        _macos_tray_refs["_dispatch_cb"] = _cb
+        _lib.dispatch_async_f.argtypes = [ctypes.c_void_p, ctypes.c_void_p, _CB]
+        _lib.dispatch_async_f.restype = None
+        _main_q = ctypes.addressof(ctypes.c_char.in_dll(_lib, "_dispatch_main_q"))
+        _lib.dispatch_async_f(_main_q, None, _cb)
+    else:
+        _setup_tray_pystray(window)
+
+
+def _on_closing():
+    if not _webview_window:
+        return
+    if _quitting:
+        return
+    behavior = load_settings().get("close_behavior", "ask")
+    if behavior == "minimize":
+        _webview_window.hide()
+        return False
+    elif behavior == "ask":
+
+        def _dispatch():
+            time.sleep(0.1)
+            if _webview_window:
+                _webview_window.evaluate_js(
+                    "window.dispatchEvent(new CustomEvent('show-close-dialog'))"
+                )
+
+        threading.Thread(target=_dispatch, daemon=True).start()
+        return False
+
+
+def _wait_for_server(port=3000, timeout=10):
+    import socket
+
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.05)


### PR DESCRIPTION
- Extract data persists and SSE (store.py), hotkey management (hotkeys.py), and webview/tray logic (tray.py) from app.py to improve maintainability.
- app.py now contains only Flask routes and startup logic