### PR TITLE
Implement v1.4.1 UI polish with new color palette

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,11 +52,21 @@ Improvements to the overall code quality of the application and test suite
 - Remove auto-creation of 'main' overlay on startup and update test accordingly
 - Add overlay picker when creating a new hunt
 
+### v1.4.3 - Data Management
+Give users full control over their hunt data - import, retroactive editing, and custom game support.
+- Import hunt data from a JSON or CSV file
+- Edit start date on active and completed hunts
+- Edit end date on completed hunts
+- Edit encounter count on completed hunts
+- Create a hunt as already completed at creation time, with optional manual start date, end date, encounters count, and game selection
+- Custom game support (for rom hack support) - persists in settings, full Pokemon list autocomplete, PokeAPI optional (graceful no-sprite fallback for custom games)
+
 ### v2.0.0 - Overlay Studio
 Deep overlay customization.
 - Custom CSS editor per overlay, with a live preview
 - Expanded display options (ability to choose exactly what each overlay shows)
 - More layout and style controls
+- Custom sprite support - upload a local image for any hunt, stored in data/sprites/ and served via the app (works in OBS overlay)
 
 ### v2.1.0 - OBS Integration
 Tighter integration with OBS beyond just being a simple browser source.

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -554,40 +554,6 @@ video {
   display: none;
 }
 
-.container {
-  width: 100%;
-}
-
-@media (min-width: 640px) {
-  .container {
-    max-width: 640px;
-  }
-}
-
-@media (min-width: 768px) {
-  .container {
-    max-width: 768px;
-  }
-}
-
-@media (min-width: 1024px) {
-  .container {
-    max-width: 1024px;
-  }
-}
-
-@media (min-width: 1280px) {
-  .container {
-    max-width: 1280px;
-  }
-}
-
-@media (min-width: 1536px) {
-  .container {
-    max-width: 1536px;
-  }
-}
-
 .pointer-events-none {
   pointer-events: none;
 }
@@ -802,10 +768,6 @@ video {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-.transform {
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
 .cursor-default {
   cursor: default;
 }
@@ -956,64 +918,56 @@ video {
   border-top-width: 1px;
 }
 
-.border-accent-muted\/30 {
-  border-color: rgb(76 201 240 / 0.3);
-}
-
 .border-danger\/20 {
   border-color: rgb(247 37 133 / 0.2);
 }
 
+.border-gold\/30 {
+  border-color: rgb(251 191 36 / 0.3);
+}
+
 .border-primary {
   --tw-border-opacity: 1;
-  border-color: rgb(114 9 183 / var(--tw-border-opacity, 1));
+  border-color: rgb(127 222 255 / var(--tw-border-opacity, 1));
+}
+
+.border-primary\/10 {
+  border-color: rgb(127 222 255 / 0.1);
 }
 
 .border-primary\/20 {
-  border-color: rgb(114 9 183 / 0.2);
+  border-color: rgb(127 222 255 / 0.2);
 }
 
 .border-primary\/30 {
-  border-color: rgb(114 9 183 / 0.3);
+  border-color: rgb(127 222 255 / 0.3);
 }
 
 .border-transparent {
   border-color: transparent;
 }
 
-.border-white\/10 {
-  border-color: rgb(255 255 255 / 0.1);
-}
-
-.border-white\/5 {
-  border-color: rgb(255 255 255 / 0.05);
-}
-
 .border-yellow-400\/40 {
   border-color: rgb(250 204 21 / 0.4);
 }
 
-.bg-accent-muted\/20 {
-  background-color: rgb(76 201 240 / 0.2);
-}
-
 .bg-bg {
   --tw-bg-opacity: 1;
-  background-color: rgb(13 11 26 / var(--tw-bg-opacity, 1));
+  background-color: rgb(44 42 74 / var(--tw-bg-opacity, 1));
 }
 
 .bg-bg-card {
   --tw-bg-opacity: 1;
-  background-color: rgb(26 16 53 / var(--tw-bg-opacity, 1));
+  background-color: rgb(37 35 65 / var(--tw-bg-opacity, 1));
 }
 
 .bg-bg-surface {
   --tw-bg-opacity: 1;
-  background-color: rgb(19 13 40 / var(--tw-bg-opacity, 1));
+  background-color: rgb(30 28 53 / var(--tw-bg-opacity, 1));
 }
 
 .bg-bg-surface\/50 {
-  background-color: rgb(19 13 40 / 0.5);
+  background-color: rgb(30 28 53 / 0.5);
 }
 
 .bg-black\/60 {
@@ -1024,25 +978,28 @@ video {
   background-color: rgb(247 37 133 / 0.1);
 }
 
-.bg-primary {
-  --tw-bg-opacity: 1;
-  background-color: rgb(114 9 183 / var(--tw-bg-opacity, 1));
+.bg-gold\/10 {
+  background-color: rgb(251 191 36 / 0.1);
 }
 
 .bg-primary\/10 {
-  background-color: rgb(114 9 183 / 0.1);
+  background-color: rgb(127 222 255 / 0.1);
 }
 
 .bg-primary\/20 {
-  background-color: rgb(114 9 183 / 0.2);
+  background-color: rgb(127 222 255 / 0.2);
 }
 
 .bg-primary\/30 {
-  background-color: rgb(114 9 183 / 0.3);
+  background-color: rgb(127 222 255 / 0.3);
 }
 
 .bg-transparent {
   background-color: transparent;
+}
+
+.bg-primary\/25 {
+  background-color: rgb(127 222 255 / 0.25);
 }
 
 .object-contain {
@@ -1262,19 +1219,6 @@ video {
   letter-spacing: 0.1em;
 }
 
-.text-accent-muted {
-  --tw-text-opacity: 1;
-  color: rgb(76 201 240 / var(--tw-text-opacity, 1));
-}
-
-.text-accent-muted\/60 {
-  color: rgb(76 201 240 / 0.6);
-}
-
-.text-accent-muted\/70 {
-  color: rgb(76 201 240 / 0.7);
-}
-
 .text-danger {
   --tw-text-opacity: 1;
   color: rgb(247 37 133 / var(--tw-text-opacity, 1));
@@ -1289,46 +1233,32 @@ video {
   color: rgb(251 191 36 / var(--tw-text-opacity, 1));
 }
 
+.text-primary {
+  --tw-text-opacity: 1;
+  color: rgb(127 222 255 / var(--tw-text-opacity, 1));
+}
+
 .text-primary-light {
   --tw-text-opacity: 1;
-  color: rgb(181 23 158 / var(--tw-text-opacity, 1));
+  color: rgb(168 238 255 / var(--tw-text-opacity, 1));
 }
 
-.text-white {
+.text-text {
   --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  color: rgb(127 222 255 / var(--tw-text-opacity, 1));
 }
 
-.text-white\/20 {
-  color: rgb(255 255 255 / 0.2);
+.text-text-muted {
+  --tw-text-opacity: 1;
+  color: rgb(144 122 214 / var(--tw-text-opacity, 1));
 }
 
-.text-white\/25 {
-  color: rgb(255 255 255 / 0.25);
+.text-text-muted\/50 {
+  color: rgb(144 122 214 / 0.5);
 }
 
-.text-white\/30 {
-  color: rgb(255 255 255 / 0.3);
-}
-
-.text-white\/40 {
-  color: rgb(255 255 255 / 0.4);
-}
-
-.text-white\/50 {
-  color: rgb(255 255 255 / 0.5);
-}
-
-.text-white\/60 {
-  color: rgb(255 255 255 / 0.6);
-}
-
-.text-white\/70 {
-  color: rgb(255 255 255 / 0.7);
-}
-
-.text-white\/80 {
-  color: rgb(255 255 255 / 0.8);
+.text-text-muted\/60 {
+  color: rgb(144 122 214 / 0.6);
 }
 
 .text-yellow-300 {
@@ -1336,16 +1266,32 @@ video {
   color: rgb(253 224 71 / var(--tw-text-opacity, 1));
 }
 
-.placeholder-white\/20::-moz-placeholder {
-  color: rgb(255 255 255 / 0.2);
+.placeholder-text-muted\/30::-moz-placeholder {
+  color: rgb(144 122 214 / 0.3);
 }
 
-.placeholder-white\/20::placeholder {
-  color: rgb(255 255 255 / 0.2);
+.placeholder-text-muted\/30::placeholder {
+  color: rgb(144 122 214 / 0.3);
+}
+
+.placeholder-text-muted\/50::-moz-placeholder {
+  color: rgb(144 122 214 / 0.5);
+}
+
+.placeholder-text-muted\/50::placeholder {
+  color: rgb(144 122 214 / 0.5);
+}
+
+.placeholder-text-muted\/60::-moz-placeholder {
+  color: rgb(144 122 214 / 0.6);
+}
+
+.placeholder-text-muted\/60::placeholder {
+  color: rgb(144 122 214 / 0.6);
 }
 
 .accent-primary {
-  accent-color: #7209B7;
+  accent-color: #7FDEFF;
 }
 
 .shadow-2xl {
@@ -1360,22 +1306,12 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.blur {
-  --tw-blur: blur(8px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .backdrop-blur-sm {
   --tw-backdrop-blur: blur(4px);
-  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-}
-
-.backdrop-filter {
   -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
@@ -1400,28 +1336,13 @@ video {
   transition-duration: 150ms;
 }
 
-.ease-in-out {
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
 .last\:border-0:last-child {
   border-width: 0px;
 }
 
-.hover\:border-primary\/40:hover {
-  border-color: rgb(114 9 183 / 0.4);
-}
-
-.hover\:border-white\/15:hover {
-  border-color: rgb(255 255 255 / 0.15);
-}
-
-.hover\:bg-accent-muted\/10:hover {
-  background-color: rgb(76 201 240 / 0.1);
-}
-
-.hover\:bg-accent-muted\/30:hover {
-  background-color: rgb(76 201 240 / 0.3);
+.hover\:border-primary:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(127 222 255 / var(--tw-border-opacity, 1));
 }
 
 .hover\:bg-danger\/10:hover {
@@ -1432,26 +1353,20 @@ video {
   background-color: rgb(247 37 133 / 0.2);
 }
 
-.hover\:bg-primary-hover:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(86 11 173 / var(--tw-bg-opacity, 1));
-}
-
 .hover\:bg-primary\/10:hover {
-  background-color: rgb(114 9 183 / 0.1);
+  background-color: rgb(127 222 255 / 0.1);
 }
 
 .hover\:bg-primary\/30:hover {
-  background-color: rgb(114 9 183 / 0.3);
+  background-color: rgb(127 222 255 / 0.3);
 }
 
-.hover\:bg-white\/5:hover {
-  background-color: rgb(255 255 255 / 0.05);
+.hover\:bg-primary\/5:hover {
+  background-color: rgb(127 222 255 / 0.05);
 }
 
-.hover\:text-accent-muted:hover {
-  --tw-text-opacity: 1;
-  color: rgb(76 201 240 / var(--tw-text-opacity, 1));
+.hover\:bg-primary\/40:hover {
+  background-color: rgb(127 222 255 / 0.4);
 }
 
 .hover\:text-danger:hover {
@@ -1459,34 +1374,32 @@ video {
   color: rgb(247 37 133 / var(--tw-text-opacity, 1));
 }
 
-.hover\:text-danger\/70:hover {
-  color: rgb(247 37 133 / 0.7);
-}
-
-.hover\:text-white:hover {
+.hover\:text-primary:hover {
   --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  color: rgb(127 222 255 / var(--tw-text-opacity, 1));
 }
 
-.hover\:text-white\/60:hover {
-  color: rgb(255 255 255 / 0.6);
+.hover\:text-text:hover {
+  --tw-text-opacity: 1;
+  color: rgb(127 222 255 / var(--tw-text-opacity, 1));
 }
 
-.hover\:text-white\/70:hover {
-  color: rgb(255 255 255 / 0.7);
+.hover\:text-text-muted:hover {
+  --tw-text-opacity: 1;
+  color: rgb(144 122 214 / var(--tw-text-opacity, 1));
 }
 
 .focus\:border-primary\/50:focus {
-  border-color: rgb(114 9 183 / 0.5);
+  border-color: rgb(127 222 255 / 0.5);
 }
 
 .focus\:border-primary\/60:focus {
-  border-color: rgb(114 9 183 / 0.6);
+  border-color: rgb(127 222 255 / 0.6);
 }
 
 .focus\:bg-bg-surface:focus {
   --tw-bg-opacity: 1;
-  background-color: rgb(19 13 40 / var(--tw-bg-opacity, 1));
+  background-color: rgb(30 28 53 / var(--tw-bg-opacity, 1));
 }
 
 .focus\:outline-none:focus {
@@ -1501,7 +1414,7 @@ video {
 }
 
 .focus\:ring-primary\/30:focus {
-  --tw-ring-color: rgb(114 9 183 / 0.3);
+  --tw-ring-color: rgb(127 222 255 / 0.3);
 }
 
 .disabled\:cursor-not-allowed:disabled {
@@ -1512,11 +1425,7 @@ video {
   opacity: 0.4;
 }
 
-.disabled\:opacity-30:disabled {
-  opacity: 0.3;
-}
-
-.group:hover .group-hover\:text-white {
+.group:hover .group-hover\:text-text {
   --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  color: rgb(127 222 255 / var(--tw-text-opacity, 1));
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,19 +1,20 @@
 module.exports = {
-    content: ["./templates/**/*.html"],
-    theme: {
-        extend: {
-            colors: {
-                bg: { DEFAULT: '#0D0B1A', surface: '#130D28', card: '#1A1035' },
-                primary: { DEFAULT: '#7209B7', hover: '#560BAD', light: '#B5179E' },
-                accent: { DEFUALT: '#4361EE', light: '#4895EF', muted: '#4CC9F0' },
-                danger: { DEFAULT: '#F72585', hover: '#B5179E' },
-                gold: '#FBBF24'
-            },
-            zIndex: {
-                '60': '60',
-                '70': '70',
-            }
-        }
+  content: ["./templates/**/*.html"],
+  theme: {
+    extend: {
+      colors: {
+        bg: { DEFAULT: "#2C2A4A", surface: "#1E1C35", card: "#252341" },
+        primary: { DEFAULT: "#7FDEFF", hover: "#60C8E8", light: "#A8EEFF" },
+        accent: { DEFAULT: "#7FDEFF", light: "#A8EEFF", muted: "#907AD6" },
+        danger: { DEFAULT: "#F72585", hover: "#B5179E" },
+        gold: "#FBBF24",
+        text: { DEFAULT: "#7FDEFF", muted: "#907AD6" },
+      },
+      zIndex: {
+        60: "60",
+        70: "70",
+      },
     },
-    plugins: []
-}
+  },
+  plugins: [],
+};

--- a/templates/control.html
+++ b/templates/control.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/static/tailwind.css">
     <link rel="stylesheet" href="/static/control.css">
 </head>
-<body class="bg-bg text-white font-sans h-screen overflow-hidden flex" x-data="app()">
+<body class="bg-bg text-text font-sans h-screen overflow-hidden flex" x-data="app()">
     <div class="flex h-full w-full">
         {% include 'partials/_sidebar.html' %}
         <main class="flex-1 flex flex-col overflow-hidden">

--- a/templates/partials/_add_hunt_form.html
+++ b/templates/partials/_add_hunt_form.html
@@ -1,8 +1,8 @@
-<div x-show="activeTab === 'hunts'" class="px-6 py-4 border-b border-white/5 bg-bg-surface/50">
+<div x-show="activeTab === 'hunts'" class="px-6 py-4 border-b border-primary/10 bg-bg-surface/50">
     <div class="flex items-end gap-3">
         <!-- Pokemon Search -->
         <div class="flex-1 max-w-xs">
-            <label class="block text-xs font-medium text-accent-muted/70 mb-1.5 uppercase tracking-wider">Pokemon</label>
+            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider">Pokemon</label>
             <div class="relative">
                 <input
                     type="text"
@@ -16,17 +16,17 @@
                     @focus="updateAutocomplete()"
                     placeholder="Search Pokemon..."
                     autocomplete="off"
-                    class="w-full bg-bg-card border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-white/20 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors duration-150"
+                    class="w-full bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text placeholder-text-muted/60 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors duration-150"
                 />
                 <!-- Autocomplete dropdown -->
                 <div
                     x-show="acOptions.length > 0"
-                    class="absolute top-full left-0 right-0 mt-1 bg-bg-card border border-white/10 rounded-lg overflow-hidden z-50 shadow-xl"
+                    class="absolute top-full left-0 right-0 mt-1 bg-bg-card border border-primary/20 rounded-lg overflow-hidden z-50 shadow-xl"
                 >
                     <template x-for="(option, index) in acOptions" :key="option">
                         <div
                             @mousedown.prevent="selectAc(option)"
-                            :class="index === acHighlight ? 'bg-primary/30 text-white' : 'text-white/80 hover:bg-white/5'"
+                            :class="index === acHighlight ? 'bg-primary/30 text-text' : 'text-text-muted hover:bg-primary/10'"
                             class="px-3 py-2 text-sm cursor-pointer transition-colors duration-100"
                             x-text="option"
                         ></div>
@@ -36,11 +36,11 @@
         </div>
         <!-- Game (optional) -->
         <div>
-            <label class="block text-xs font-medium text-accent-muted/70 mb-1.5 uppercase tracking-wider">Game <span class="text-white/20 normal-case tracking-normal">(optional)</span></label>
+            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider">Game <span class="text-text-muted/50 normal-case tracking-normal">(optional)</span></label>
             <select
                 x-model="newHunt.game"
                 @change="onGameChange()"
-                class="bg-bg-card border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-primary/60 transition-colors duration-150 cursor-pointer"
+                class="bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-primary/60 transition-colors duration-150 cursor-pointer"
             >
                 <option value="">Any Game</option>
                 <template x-for="game in games" :key="game">
@@ -52,7 +52,7 @@
         <button
             @click="addHunt()"
             :disabled="newHunt.loading || !newHunt.name.trim()"
-            class="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-hover disabled:opacity-40 disabled:cursor-not-allowed rounded-lg text-sm font-semibold text-white transition-colors duration-150"
+            class="flex items-center gap-2 px-4 py-2 border border-primary/30 bg-primary/25 hover:bg-primary/40 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg text-sm font-semibold text-text transition-colors duration-150"
         >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />

--- a/templates/partials/_history_tab.html
+++ b/templates/partials/_history_tab.html
@@ -5,12 +5,12 @@
         class="flex flex-col items-center justify-center h-full text-center py-16"
     >
         <div class="text-5xl mb-4">🏆</div>
-        <div class="text-white/40 text-sm font-medium">No completed hunts yet</div>
-        <div class="text-white/20 text-xs mt-1">Mark a hunt as found to see it here</div>
+        <div class="text-text-muted text-sm font-medium">No completed hunts yet</div>
+        <div class="text-text-muted/50 text-xs mt-1">Mark a hunt as found to see it here</div>
     </div>
     <!-- Completed Hunt Cards -->
     <template x-for="hunt in hunts.filter(h => h.status === 'completed')" :key="hunt.id">
-        <div class="bg-bg-card border border-white/8 rounded-xl p-4 flex items-center gap-4 hover:border-white/15 transition-colors duration-150">
+        <div class="bg-bg-card rounded-xl p-4 flex items-center gap-4 transition-colors duration-150">
             <!-- Sprite -->
             <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center">
                 <template x-if="hunt.spriteUrl">
@@ -23,16 +23,16 @@
             <!-- Info -->
             <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2">
-                    <span class="text-sm font-semibold text-white truncate" x-text="hunt.displayName"></span>
-                    <span x-show="hunt.game" class="text-xs text-white/30 truncate" x-text="hunt.game"></span>
+                    <span class="text-sm font-semibold text-text truncate" x-text="hunt.displayName"></span>
+                    <span x-show="hunt.game" class="text-xs text-text-muted/50 truncate" x-text="hunt.game"></span>
                 </div>
                 <div class="flex items-center gap-3 mt-0.5">
-                    <span class="text-xs text-white/30">
+                    <span class="text-xs text-text-muted/50">
                         <span x-text="new Date(hunt.startDate * 1000).toLocaleDateString()"></span>
                         <span x-show="hunt.endDate"> → <span x-text="new Date(hunt.endDate * 1000).toLocaleDateString()"></span></span>
                     </span>
                 </div>
-                <div x-show="hunt.notes" class="mt-1 text-xs text-accent-muted/60 italic truncate" x-text="hunt.notes"></div>
+                <div x-show="hunt.notes" class="mt-1 text-xs text-text-muted italic truncate" x-text="hunt.notes"></div>
             </div>
             <!-- Final Count -->
             <div class="flex-shrink-0 text-gold font-bold text-lg tabular-nums" x-text="hunt.count.toLocaleString('en-US')"></div>
@@ -40,7 +40,7 @@
             <button
                 @click="deleteHunt(hunt.id)"
                 title="Delete"
-                class="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded-lg text-white/25 hover:text-danger hover:bg-danger/10 transition-colors duration-150"
+                class="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded-lg text-text-muted/50 hover:text-danger hover:bg-danger/10 transition-colors duration-150"
             >
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/templates/partials/_hunts_tab.html
+++ b/templates/partials/_hunts_tab.html
@@ -5,12 +5,12 @@
         class="flex flex-col items-center justify-center h-full text-center py-16"
     >
         <div class="text-5xl mb-4">✨</div>
-        <div class="text-white/40 text-sm font-medium">No active hunts</div>
-        <div class="text-white/20 text-xs mt-1">Search for a Pokemon above to get started</div>
+        <div class="text-text-muted text-sm font-medium">No active hunts</div>
+        <div class="text-text-muted/50 text-xs mt-1">Search for a Pokemon above to get started</div>
     </div>
     <!-- Hunt Cards -->
     <template x-for="hunt in hunts.filter(h => h.status === 'active' || !h.status)" :key="hunt.id">
-        <div class="bg-bg-card border border-white/8 rounded-xl p-4 flex items-center gap-4 hover:border-white/15 transition-colors duration-150">
+        <div class="bg-bg-card rounded-xl p-4 flex items-center gap-4 transition-colors duration-150">
             <!-- Sprite -->
             <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center">
                 <template x-if="hunt.spriteUrl">
@@ -22,11 +22,11 @@
             </div>
             <!-- Name + Game + Odds -->
             <div class="flex-shrink-0 w-36">
-                <div class="text-sm font-semibold text-white truncate" x-text="hunt.displayName"></div>
+                <div class="text-sm font-semibold text-text truncate" x-text="hunt.displayName"></div>
                 <select
                     :value="hunt.game"
                     @change="updateGame(hunt.id, $event.target.value)"
-                    class="w-full mt-1 bg-bg-surface border border-white/10 rounded px-2 py-0.5 text-xs text-accent-muted/70 focus:outline-none focus:border-primary/50 cursor-pointer"
+                    class="w-full mt-1 bg-bg-surface border border-primary/30 rounded px-2 py-0.5 text-xs text-text-muted focus:outline-none focus:border-primary/50 cursor-pointer"
                 >
                     <option value="" :selected="!hunt.game">No Game</option>
                     <template x-for="game in games" :key="game">
@@ -38,31 +38,31 @@
                     :value="hunt.encounterRate"
                     @change="updateEncounterRate(hunt.id, $event.target.value)"
                     placeholder="Odds"
-                    class="w-full mt-1 bg-bg-surface border border-white/10 rounded px-2 py-0.5 text-xs text-white/70 focus:outline-none focus:border-primary/50"
+                    class="w-full mt-1 bg-bg-surface border border-primary/20 rounded px-2 py-0.5 text-xs text-text-muted placeholder-text-muted/50 focus:outline-none focus:border-primary/50"
                 />
             </div>
             <!-- Hotkeys -->
             <div class="flex-1 min-w-0 flex gap-3">
                 <!-- Increment Hotkey -->
                 <div class="flex items-center gap-1.5">
-                    <span class="text-xs text-white/30 font-medium">+</span>
+                    <span class="text-xs text-text-muted font-medium">+</span>
                     <template x-if="capture.huntId === hunt.id && capture.field === 'hotkey'">
                         <div class="flex items-center gap-1.5">
-                            <span class="text-xs text-accent-muted listening">Press a key...</span>
-                            <button @click="cancelCapture()" title="Cancel capture" class="text-xs text-white/30 hover:text-white/60 transition-colors">✕</button>
+                            <span class="text-xs text-primary listening">Press a key...</span>
+                            <button @click="cancelCapture()" title="Cancel capture" class="text-xs text-text-muted hover:text-text transition-colors">✕</button>
                         </div>
                     </template>
                     <template x-if="!(capture.huntId === hunt.id && capture.field === 'hotkey')">
                         <div class="flex items-center gap-1">
                             <template x-if="hunt.hotkey">
-                                <span class="px-1.5 py-0.5 bg-bg-surface border border-white/10 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkey)"></span>
+                                <span class="px-1.5 py-0.5 bg-gold/10 border border-gold/30 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkey)"></span>
                             </template>
                             <template x-if="hunt.hotkey">
-                                <button @click="clearHotkey(hunt.id, 'hotkey')" title="Clear increment hotkey" class="text-white/20 hover:text-danger/70 transition-colors text-xs">✕</button>
+                                <button @click="clearHotkey(hunt.id, 'hotkey')" title="Clear increment hotkey" class="text-text-muted/50 hover:text-danger transition-colors text-xs">✕</button>
                             </template>
                             <button
                                 @click="startCapture(hunt.id, 'hotkey')"
-                                class="px-2 py-0.5 bg-bg-surface border border-white/10 hover:border-primary/40 rounded text-xs text-white/40 hover:text-white/70 transition-colors duration-150"
+                                class="px-2 py-0.5 bg-bg-surface border border-primary/20 hover:border-primary rounded text-xs text-text-muted hover:text-text transition-colors duration-150"
                                 x-text="hunt.hotkey ? 'Change' : 'Set'"
                             ></button>
                         </div>
@@ -70,24 +70,24 @@
                 </div>
                 <!-- Decrement Hotkey -->
                 <div class="flex items-center gap-1.5">
-                    <span class="text-xs text-white/30 font-medium">-</span>
+                    <span class="text-xs text-text-muted font-medium">-</span>
                     <template x-if="capture.huntId === hunt.id && capture.field === 'hotkeyDecrement'">
                         <div class="flex items-center gap-1.5">
-                            <span class="text-xs text-accent-muted listening">Press a key...</span>
-                            <button @click="cancelCapture()" title="Cancel capture" class="text-xs text-white/30 hover:text-white/60 transition-colors">✕</button>
+                            <span class="text-xs text-primary listening">Press a key...</span>
+                            <button @click="cancelCapture()" title="Cancel capture" class="text-xs text-text-muted hover:text-text transition-colors">✕</button>
                         </div>
                     </template>
                     <template x-if="!(capture.huntId === hunt.id && capture.field === 'hotkeyDecrement')">
                         <div class="flex items-center gap-1">
                             <template x-if="hunt.hotkeyDecrement">
-                                <span class="px-1.5 py-0.5 bg-bg-surface border border-white/10 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkeyDecrement)"></span>
+                                <span class="px-1.5 py-0.5 bg-gold/10 border border-gold/30 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkeyDecrement)"></span>
                             </template>
                             <template x-if="hunt.hotkeyDecrement">
-                                <button @click="clearHotkey(hunt.id, 'hotkeyDecrement')" title="Clear decrement hotkey" class="text-white/20 hover:text-danger/70 transition-colors text-xs">✕</button>
+                                <button @click="clearHotkey(hunt.id, 'hotkeyDecrement')" title="Clear decrement hotkey" class="text-text-muted/50 hover:text-danger transition-colors text-xs">✕</button>
                             </template>
                             <button
                                 @click="startCapture(hunt.id, 'hotkeyDecrement')"
-                                class="px-2 py-0.5 bg-bg-surface border border-white/10 hover:border-primary/40 rounded text-xs text-white/40 hover:text-white/70 transition-colors duration-150"
+                                class="px-2 py-0.5 bg-bg-surface border border-primary/20 hover:border-primary rounded text-xs text-text-muted hover:text-text transition-colors duration-150"
                                 x-text="hunt.hotkeyDecrement ? 'Change' : 'Set'"
                             ></button>
                         </div>
@@ -98,7 +98,7 @@
             <div class="flex-shrink-0 flex items-center gap-1.5">
                 <button
                     @click="decrement(hunt.id)"
-                    class="w-7 h-7 flex items-center justify-center rounded-lg bg-bg-surface border border-white/10 hover:border-primary/40 hover:bg-primary/10 text-white/60 hover:text-white transition-colors duration-150 text-lg leading-none"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg bg-bg-surface border border-primary/20 hover:border-primary hover:bg-primary/10 text-text-muted hover:text-text transition-colors duration-150 text-lg leading-none"
                 >-</button>
                 <input
                     type="number"
@@ -108,7 +108,7 @@
                 />
                 <button
                     @click="increment(hunt.id)"
-                    class="w-7 h-7 flex items-center justify-center rounded-lg bg-bg-surface border border-white/10 hover:border-primary/40 hover:bg-primary/10 text-white/60 hover:text-white transition-colors duration-150 text-lg leading-none"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg bg-bg-surface border border-primary/20 hover:border-primary hover:bg-primary/10 text-text-muted hover:text-text transition-colors duration-150 text-lg leading-none"
                 >+</button>
             </div>
             <!-- Actions -->
@@ -117,7 +117,7 @@
                 <button
                     @click="resetHunt(hunt.id)"
                     title="Reset count"
-                    class="w-7 h-7 flex items-center justify-center rounded-lg text-white/25 hover:text-white/60 hover:bg-white/5 transition-colors duration-150"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg text-text-muted/50 hover:text-text-muted hover:bg-primary/10 transition-colors duration-150"
                 >
                     <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -126,7 +126,7 @@
                 <button
                     @click="markFound(hunt)"
                     title="Mark as Found"
-                    class="w-7 h-7 flex items-center justify-center rounded-lg text-white/25 hover:text-accent-muted hover:bg-accent-muted/10 transition-colors duration-150"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg text-text-muted/50 hover:text-primary hover:bg-primary/10 transition-colors duration-150"
                 >
                     <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
@@ -136,7 +136,7 @@
                 <button
                     @click="deleteHunt(hunt.id)"
                     title="Delete Hunt"
-                    class="w-7 h-7 flex items-center justify-center rounded-lg text-white/25 hover:text-danger hover:bg-danger/10 transition-colors duration-150"
+                    class="w-7 h-7 flex items-center justify-center rounded-lg text-text-muted/50 hover:text-danger hover:bg-danger/10 transition-colors duration-150"
                 >
                     <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/templates/partials/_modals.html
+++ b/templates/partials/_modals.html
@@ -5,13 +5,13 @@
     style="z-index: 60;"
     class="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm"
 >
-    <div class="bg-bg-surface border border-white/10 rounded-2xl p-6 w-80 shadow-2xl">
-        <div class="text-base font-semibold text-white mb-1">Close Shiny Trak?</div>
-        <div class="text-sm text-white/40 mb-5">What would you like to do?</div>
+    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-80 shadow-2xl">
+        <div class="text-base font-semibold text-text mb-1">Close Shiny Trak?</div>
+        <div class="text-sm text-text-muted mb-5">What would you like to do?</div>
         <div class="flex flex-col gap-2">
             <button
                 @click="confirmClose('minimize')"
-                class="w-full px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-white text-left transition-colors duration-150"
+                class="w-full px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text text-left transition-colors duration-150"
             >Minimize to tray</button>
             <button
                 @click="confirmClose('quit')"
@@ -19,7 +19,7 @@
             >Quit Shiny Trak</button>
             <button
                 @click="confirmClose('cancel')"
-                class="w-full px-4 py-2.5 hover:bg-white/5 rounded-lg text-sm font-medium text-white/40 hover:text-white/60 text-left transition-colors duration-150"
+                class="w-full px-4 py-2.5 hover:bg-primary/10 rounded-lg text-sm font-medium text-text-muted hover:text-text-muted text-left transition-colors duration-150"
             >Cancel</button>
         </div>
     </div>
@@ -31,10 +31,10 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     @click.self="showSettings = false"
 >
-    <div class="bg-bg-surface border border-white/10 rounded-2xl p-6 w-96 shadow-2xl">
+    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl">
         <div class="flex items-center justify-between mb-5">
-            <div class="text-base font-semibold text-white">Settings</div>
-            <button @click="showSettings = false" class="text-white/30 hover:text-white/60 transition-colors">
+            <div class="text-base font-semibold text-text">Settings</div>
+            <button @click="showSettings = false" class="text-text-muted/50 hover:text-text-muted transition-colors">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -42,10 +42,10 @@
         </div>
         <!-- Close Behavior -->
         <div>
-            <div class="text-xs font-medium text-accent-muted/70 uppercase tracking-wider mb-3">When closing the window</div>
+            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">When closing the window</div>
             <div class="space-y-1.5">
                 <template x-for="opt in [{value:'ask',label:'Ask every time'},{value:'minimize',label:'Minimize to tray'},{value:'quit',label:'Quit'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-white/5 cursor-pointer transition-colors duration-150">
+                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
                         <input
                             type="radio"
                             name="close_behavior"
@@ -54,17 +54,17 @@
                             @change="saveSettings()"
                             class="accent-primary"
                         />
-                        <span class="text-sm text-white/80" x-text="opt.label"></span>
+                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
                     </label>
                 </template>
             </div>
         </div>
         <!-- Mark Found Behavior -->
-        <div class="mt-5 pt-5 border-t border-white/5">
-            <div class="text-xs font-medium text-accent-muted/70 uppercase tracking-wider mb-3">When marking a hunt as found</div>
+        <div class="mt-5 pt-5 border-t border-primary/10">
+            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">When marking a hunt as found</div>
             <div class="space-y-1.5">
                 <template x-for="opt in [{value:'ask',label:'Ask for notes'},{value:'never',label:'Complete immediately'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-white/5 cursor-pointer transition-colors duration-150">
+                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
                         <input
                             type="radio"
                             name="mark_found_behavior"
@@ -73,22 +73,22 @@
                             @change="saveSettings()"
                             class="accent-primary"
                         />
-                        <span class="text-sm text-white/80" x-text="opt.label"></span>
+                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
                     </label>
                 </template>
             </div>
         </div>
         <!-- Milestone Alerts -->
-        <div class="mt-5 pt-5 border-t border-white/5">
-            <div class="text-xs font-medium text-accent-muted/70 uppercase tracking-wider mb-3">Milestone Alerts</div>
-            <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-white/5 cursor-pointer transition-colors duration-150">
+        <div class="mt-5 pt-5 border-t border-primary/10">
+            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Milestone Alerts</div>
+            <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
                 <input
                     type="checkbox"
                     x-model="settings.milestone_alerts"
                     @change="saveSettings()"
                     class="accent-primary"
                 />
-                <span class="text-sm text-white/80">Show alerts when a hunt reaches 1x, 2x, 3x odds</span>
+                <span class="text-sm text-text-muted">Show alerts when a hunt reaches 1x, 2x, 3x odds</span>
             </label>
         </div>
     </div>
@@ -100,13 +100,13 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     @click.self="showMarkFound = false"
 >
-    <div class="bg-bg-surface border border-white/10 rounded-2xl p-6 w-96 shadow-2xl">
+    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl">
         <div class="flex items-center justify-between mb-5">
             <div>
-                <div class="text-base font-semibold text-white">Mark as Found</div>
-                <div class="text-sm text-white/40 mt-0.5" x-text="markFoundHunt ? markFoundHunt.displayName : ''"></div>
+                <div class="text-base font-semibold text-text">Mark as Found</div>
+                <div class="text-sm text-text-muted mt-0.5" x-text="markFoundHunt ? markFoundHunt.displayName : ''"></div>
             </div>
-            <button @click="showMarkFound = false" class="text-white/30 hover:text-white/60 transition-colors">
+            <button @click="showMarkFound = false" class="text-text-muted/50 hover:text-text-muted transition-colors">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -114,22 +114,22 @@
         </div>
         <!-- Notes -->
         <div class="mb-5">
-            <label class="block text-xs font-medium text-accent-muted/70 uppercase tracking-wider mb-1.5">Notes <span class="text-white/20 normal-case tracking-normal">(optional)</span></label>
+            <label class="block text-xs font-medium text-text-muted uppercase tracking-wider mb-1.5">Notes <span class="text-text-muted/50 normal-case tracking-normal">(optional)</span></label>
             <textarea
                 x-model="markFoundNotes"
                 placeholder="How did you find it? Any thoughts..."
                 rows="3"
-                class="w-full bg-bg-card border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-white/20 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors duration-150 resize-none"></textarea>
+                class="w-full bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text placeholder-text-muted/30 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors duration-150 resize-none"></textarea>
         </div>
         <!-- Actions -->
         <div class="flex gap-2">
             <button
                 @click="confirmMarkFound()"
-                class="flex-1 px-4 py-2.5 bg-accent-muted/20 hover:bg-accent-muted/30 border border-accent-muted/30 rounded-lg text-sm font-medium text-accent-muted transition-colors duration-150"
+                class="flex-1 px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150"
             >Mark as Found</button>
             <button
                 @click="showMarkFound = false"
-                class="px-4 py-2.5 hover:bg-white/5 rounded-lg text-sm font-medium text-white/40 hover:text-white/60 transition-colors duration-150"
+                class="px-4 py-2.5 hover:bg-primary/10 rounded-lg text-sm font-medium text-text-muted hover:text-text-muted transition-colors duration-150"
             >Cancel</button>
         </div>
     </div>
@@ -141,10 +141,10 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     @click.self="showExport = false"
 >
-    <div class="bg-bg-surface border border-white/10 rounded-2xl p-6 w-96 shadow-2xl">
+    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl">
         <div class="flex items-center justify-between mb-5">
-            <div class="text-base font-semibold text-white">Export Hunts</div>
-            <button @click="showExport = false" class="text-white/30 hover:text-white/60 transition-colors">
+            <div class="text-base font-semibold text-text">Export Hunts</div>
+            <button @click="showExport = false" class="text-text-muted/50 hover:text-text-muted transition-colors">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -152,24 +152,24 @@
         </div>
         <!-- Scope -->
         <div class="mb-5">
-            <div class="text-xs font-medium text-accent-muted/70 uppercase tracking-wider mb-3">Include</div>
+            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Include</div>
             <div class="space-y-1.5">
                 <template x-for="opt in [{value:'all',label:'All hunts'},{value:'active',label:'Active hunts only'},{value:'completed',label:'Completed hunts only'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-white/5 cursor-pointer transition-colors duration-150">
+                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
                         <input type="radio" name="export_scope" :value="opt.value" x-model="exportScope" class="accent-primary" />
-                        <span class="text-sm text-white/80" x-text="opt.label"></span>
+                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
                     </label>
                 </template>
             </div>
         </div>
         <!-- Format -->
         <div class="mb-5">
-            <div class="text-xs font-medium text-accent-muted/70 uppercase tracking-wider mb-3">Format</div>
+            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Format</div>
             <div class="space-y-1.5">
                 <template x-for="opt in [{value:'json',label:'JSON'},{value:'csv',label:'CSV'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-white/5 cursor-pointer transition-colors duration-150">
+                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
                         <input type="radio" name="export_format" :value="opt.value" x-model="exportFormat" class="accent-primary" />
-                        <span class="text-sm text-white/80" x-text="opt.label"></span>
+                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
                     </label>
                 </template>
             </div>
@@ -177,7 +177,7 @@
         <!-- Download -->
         <button
             @click="exportHunts(exportScope, exportFormat);"
-            class="w-full px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-white transition-colors duration-150"
+            class="w-full px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150"
         >Download</button>
     </div>
 </div>
@@ -186,12 +186,12 @@
     x-show="exportMessage"
     x-transition.opacity
     style="z-index: 70;"
-    class="fixed bottom-5 right-5 bg-bg-surface border border-white/10 rounded-xl px-4 py-3 shadow-2xl flex items-center gap-3"
+    class="fixed bottom-5 right-5 bg-bg-surface border border-primary/20 rounded-xl px-4 py-3 shadow-2xl flex items-center gap-3"
 >
-    <svg class="w-4 h-4 text-accent-muted flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg class="w-4 h-4 text-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
     </svg>
-    <span class="text-sm text-white/80" x-text="exportMessage"></span>
+    <span class="text-sm text-text-muted" x-text="exportMessage"></span>
 </div>
 <!-- Milestone Alert Banner -->
 <div

--- a/templates/partials/_overlays_tab.html
+++ b/templates/partials/_overlays_tab.html
@@ -1,23 +1,23 @@
 <div x-show="activeTab === 'overlays'" class="flex-1 flex flex-col overflow-hidden">
     <!-- Sub-Tab Switcher -->
-    <div class="px-6 pt-3 flex gap-1 border-b border-white/5">
+    <div class="px-6 pt-3 flex gap-1 border-b border-primary/10">
         <button
             @click="overlaySubTab = 'hunt'"
-            :class="overlaySubTab === 'hunt' ? 'border-b-2 border-primary text-white' : 'text-white/40 hover:text-white/60'"
+            :class="overlaySubTab === 'hunt' ? 'border-b-2 border-primary text-text' : 'text-text-muted hover:text-text'"
             class="text-sm font-medium px-3 pb-2 transition-colors duration-150">
             Hunt Overlays
         </button>
         <button
             @click="overlaySubTab = 'stats'"
-            :class="overlaySubTab === 'stats' ? 'border-b-2 border-primary text-white' : 'text-white/40 hover:text-white/60'"
+            :class="overlaySubTab === 'stats' ? 'border-b-2 border-primary text-text' : 'text-text-muted hover:text-text'"
             class="text-sm font-medium px-3 pb-2 transition-colors duration-150">
             Stats Overlays
         </button>
     </div>
     <!-- New Overlay Header -->
-    <div class="px-6 py-3 border-b border-white/5 flex items-center gap-2">
+    <div class="px-6 py-3 border-b border-primary/10 flex items-center gap-2">
         <div x-show="!showNewOverlay">
-            <button @click="showNewOverlay = true" class="flex items-center gap-2 px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-white transition-colors duration-150">
+            <button @click="showNewOverlay = true" class="flex items-center gap-2 px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150">
                 + New Overlay
             </button>
         </div>
@@ -28,34 +28,34 @@
                 @keydown.enter="addOverlay()"
                 @keydown.escape="showNewOverlay = false; newOverlayName = ''"
                 placeholder="Overlay name..."
-                class="bg-bg-card border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-white/20 focus:outline-none focus:border-primary/60 transition-colors duration-150"
+                class="bg-bg-card border border-primary/20 rounded-lg px-3 py-1.5 text-sm text-text placeholder-text-muted/30 focus:outline-none focus:border-primary/60 transition-colors duration-150"
             />
-            <button @click="addOverlay()" class="px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-white transition-colors duration-150">Add</button>
-            <button @click="showNewOverlay = false; newOverlayName = ''" class="text-white/30 hover:text-white/60 text-sm transition-colors">Cancel</button>
+            <button @click="addOverlay()" class="px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150">Add</button>
+            <button @click="showNewOverlay = false; newOverlayName = ''" class="text-text-muted/50 hover:text-text-muted text-sm transition-colors">Cancel</button>
         </div>
     </div>
     <!-- Overlay Cards -->
     <div class="flex-1 overflow-y-auto px-6 py-4 space-y-3">
         <template x-for="overlay in overlays.filter(o => (o.type || 'hunt') === overlaySubTab)" :key="overlay.id">
-            <div class="bg-bg-card border border-white/8 rounded-xl overflow-hidden">
+            <div class="bg-bg-card rounded-xl overflow-hidden">
                 <!-- Overlay Header -->
-                <div class="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-white/3 transition-colors duration-150"
+                <div class="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-primary/5 transition-colors duration-150"
                     @click="selectedOverlayId = selectedOverlayId === overlay.id ? null : overlay.id">
-                    <span class="flex-1 text-sm font-semibold text-white" x-text="overlay.name"></span>
-                    <button @click.stop="copyOverlayUrl(overlay)" title="Copy overlay URL" class="text-xs text-accent-muted/60 hover:text-accent-muted transition-colors px-2 py-1 rounded hover:bg-white/5">Copy URL</button>
-                    <button @click.stop="deleteOverlay(overlay.id)" title="Delete overlay" class="text-white/25 hover:text-danger hover:bg-danger/10 rounded p-1 transition-colors duration-150">
+                    <span class="flex-1 text-sm font-semibold text-text" x-text="overlay.name"></span>
+                    <button @click.stop="copyOverlayUrl(overlay)" title="Copy overlay URL" class="text-xs text-text-muted hover:text-text transition-colors px-2 py-1 rounded hover:bg-primary/10">Copy URL</button>
+                    <button @click.stop="deleteOverlay(overlay.id)" title="Delete overlay" class="text-text-muted/50 hover:text-danger hover:bg-danger/10 rounded p-1 transition-colors duration-150">
                         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                         </svg>
                     </button>
-                    <svg class="w-4 h-4 text-white/30 transition-transform duration-150" :class="selectedOverlayId === overlay.id ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-4 h-4 text-text-muted/50 transition-transform duration-150" :class="selectedOverlayId === overlay.id ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                     </svg>
                 </div>
                 <!-- Hunt Overlay Config -->
-                <div x-show="selectedOverlayId === overlay.id && (overlay.type || 'hunt') === 'hunt'" class="border-t border-white/5 px-4 py-2 space-y-1">
+                <div x-show="selectedOverlayId === overlay.id && (overlay.type || 'hunt') === 'hunt'" class="border-t border-primary/10 px-4 py-2 space-y-1">
                     <template x-if="hunts.filter(h => h.status === 'active' || !h.status).length === 0">
-                        <div class="text-xs text-white/30 py-2">No active hunts</div>
+                        <div class="text-xs text-text-muted/50 py-2">No active hunts</div>
                     </template>
                     <template x-for="hunt in hunts.filter(h => h.status === 'active' || !h.status)" :key="hunt.id">
                         <label class="flex items-center gap-3 py-1.5 cursor-pointer group">
@@ -66,43 +66,43 @@
                                 class="accent-primary"
                             />
                             <img x-show="hunt.spriteUrl" :src="hunt.spriteUrl" class="w-6 h-6 object-contain" style="image-rendering: pixelated;" />
-                            <span class="text-sm text-white/70 group-hover:text-white transition-colors" x-text="hunt.displayName"></span>
+                            <span class="text-sm text-text-muted group-hover:text-text transition-colors" x-text="hunt.displayName"></span>
                         </label>
                     </template>
-                    <div class="border-t border-white/5 px-4 py-2 flex items-center gap-4">
-                        <span class="text-xs text-white/30 uppercase tracking-wider">Show</span>
+                    <div class="border-t border-primary/10 px-4 py-2 flex items-center gap-4">
+                        <span class="text-xs text-text-muted/50 uppercase tracking-wider">Show</span>
                         <label class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.sprite" @change="updateOverlayElement(overlay.id, 'sprite', $event.target.checked)" class="accent-primary" />
-                            <span class="text-xs text-white/50">Sprite</span>
+                            <span class="text-xs text-text-muted">Sprite</span>
                         </label>
                         <label class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.name" @change="updateOverlayElement(overlay.id, 'name', $event.target.checked)" class="accent-primary" />
-                            <span class="text-xs text-white/50">Name</span>
+                            <span class="text-xs text-text-muted">Name</span>
                         </label>
                         <label class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.count" @change="updateOverlayElement(overlay.id, 'count', $event.target.checked)" class="accent-primary" />
-                            <span class="text-xs text-white/50">Count</span>
+                            <span class="text-xs text-text-muted">Count</span>
                         </label>
                         <label class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.odds" @change="updateOverlayElement(overlay.id, 'odds', $event.target.checked)" class="accent-primary" />
-                            <span class="text-xs text-white/50">Odds</span>
+                            <span class="text-xs text-text-muted">Odds</span>
                         </label>
                     </div>
                 </div>
                 <!-- Stats Overlay Config -->
-                <div x-show="selectedOverlayId === overlay.id && overlay.type === 'stats'" class="border-t border-white/5 px-4 py-3 space-y-3">
+                <div x-show="selectedOverlayId === overlay.id && overlay.type === 'stats'" class="border-t border-primary/10 px-4 py-3 space-y-3">
                     <!-- Total Completed Toggle -->
                     <label class="flex items-center gap-3 cursor-pointer">
                         <input type="checkbox" :checked="overlay.elements.totalCompleted" @change="updateOverlayElement(overlay.id, 'totalCompleted', $event.target.checked)" class="accent-primary" />
-                        <span class="text-sm text-white/70">Show total completed hunts</span>
+                        <span class="text-sm text-text-muted">Show total completed hunts</span>
                     </label>
                     <!-- Breakdown -->
                     <div class="flex items-center gap-3">
-                        <span class="text-xs text-white/30 uppercase tracking-wider">Breakdown</span>
+                        <span class="text-xs text-text-muted/50 uppercase tracking-wider">Breakdown</span>
                         <select
                             :value="overlay.elements.breakdown"
                             @change="updateOverlayElement(overlay.id, 'breakdown', $event.target.value || null)"
-                            class="bg-bg-surface border border-white/10 rounded-lg px-2 py-1 text-sm text-white/70 focus:outline-none focus:border-primary/60">
+                            class="bg-bg-surface border border-primary/20 rounded-lg px-2 py-1 text-sm text-text-muted focus:outline-none focus:border-primary/60">
                             <option value="">None</option>
                             <option value="completed">Completed hunts</option>
                             <option value="active">Active hunts</option>
@@ -110,11 +110,11 @@
                     </div>
                     <!-- Game Filter -->
                     <div class="flex items-center gap-3">
-                        <span class="text-xs text-white/30 uppercase tracking-wider">Game</span>
+                        <span class="text-xs text-text-muted/50 uppercase tracking-wider">Game</span>
                         <select
                             :value="overlay.game || ''"
                             @change="updateOverlayGame(overlay.id, $event.target.value)"
-                            class="bg-bg-surface border border-white/10 rounded-lg px-2 py-1 text-sm text-white/70 focus:outline-none focus:border-primary/60">
+                            class="bg-bg-surface border border-primary/20 rounded-lg px-2 py-1 text-sm text-text-muted focus:outline-none focus:border-primary/60">
                             <option value="">All Games</option>
                             <template x-for="game in games" :key="game">
                                 <option :value="game" x-text="game"></option>

--- a/templates/partials/_sidebar.html
+++ b/templates/partials/_sidebar.html
@@ -1,11 +1,11 @@
-<aside class="w-56 flex-shrink-0 flex flex-col bg-bg-surface border-r border-white/5">
+<aside class="w-56 flex-shrink-0 flex flex-col bg-bg-surface border-r border-primary/10">
     <!-- Application Title -->
-    <div class="px-5 py-5 border-b border-white/5">
+    <div class="px-5 py-5 border-b border-primary/10">
         <div class="flex items-center gap-2.5">
             <span class="text-xl">✨</span>
             <div>
-                <div class="text-sm font-bold tracking-wide text-white">Shiny Trak</div>
-                <div class="text-xs text-accent-muted/60 font-medium" x-text="`${hunts.filter(h => h.status === 'active' || !h.status).length} active hunt${hunts.filter(h => h.status === 'active' || !h.status).length !== 1 ? 's' : ''}`"></div>
+                <div class="text-sm font-bold tracking-wide text-text">Shiny Trak</div>
+                <div class="text-xs text-text-muted/60 font-medium" x-text="`${hunts.filter(h => h.status === 'active' || !h.status).length} active hunt${hunts.filter(h => h.status === 'active' || !h.status).length !== 1 ? 's' : ''}`"></div>
             </div>
         </div>
     </div>
@@ -14,55 +14,55 @@
         <div class="space-y-0.5">
             <div
                 @click="activeTab = 'hunts'"
-                :class="activeTab === 'hunts' ? 'bg-primary/20 border-l-2 border-primary cursor-default' : 'border-l-2 border-transparent hover:bg-white/5 cursor-pointer'"
+                :class="activeTab === 'hunts' ? 'bg-primary/20 border-l-2 border-primary cursor-default' : 'border-l-2 border-transparent hover:bg-primary/10 cursor-pointer'"
                 class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors duration-150"
             >
-                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'hunts' ? 'text-primary-light' : 'text-white/40'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'hunts' ? 'text-primary-light' : 'text-text-muted'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                 </svg>
-                <span class="text-sm font-medium" :class="activeTab === 'hunts' ? 'text-white' : 'text-white/40'">Hunts</span>
+                <span class="text-sm font-medium" :class="activeTab === 'hunts' ? 'text-text' : 'text-text-muted'">Hunts</span>
             </div>
             <div
                 @click="activeTab = 'history'"
-                :class="activeTab === 'history' ? 'bg-primary/20 border-l-2 border-primary' : 'border-l-2 border-transparent hover:bg-white/5'"
+                :class="activeTab === 'history' ? 'bg-primary/20 border-l-2 border-primary' : 'border-l-2 border-transparent hover:bg-primary/10'"
                 class="flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors duration-150"
             >
-                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'history' ? 'text-primary-light' : 'text-white/40'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'history' ? 'text-primary-light' : 'text-text-muted'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span class="text-sm font-medium" :class="activeTab === 'history' ? 'text-white' : 'text-white/40'">History</span>
+                <span class="text-sm font-medium" :class="activeTab === 'history' ? 'text-text' : 'text-text-muted'">History</span>
             </div>
             <div
                 @click="activeTab = 'overlays'"
-                :class="activeTab === 'overlays' ? 'bg-primary/20 border-l-2 border-primary' : 'border-l-2 border-transparent hover:bg-white/5'"
+                :class="activeTab === 'overlays' ? 'bg-primary/20 border-l-2 border-primary' : 'border-l-2 border-transparent hover:bg-primary/10'"
                 class="flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors duration-150"
             >
-                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'overlays' ? 'text-primary-light' : 'text-white/40'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'overlays' ? 'text-primary-light' : 'text-text-muted'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                 </svg>
-                <span class="text-sm font-medium" :class="activeTab === 'overlays' ? 'text-white' : 'text-white/40'">Overlays</span>
+                <span class="text-sm font-medium" :class="activeTab === 'overlays' ? 'text-text' : 'text-text-muted'">Overlays</span>
             </div>
         </div>
         <div class="mt-auto pt-0.5">
             <div
                 @click="activeTab = 'stats'"
-                :class="activeTab === 'stats' ? 'bg-primary/20 border-l-2 border-primary' : 'border-l-2 border-transparent hover:bg-white/5'"
+                :class="activeTab === 'stats' ? 'bg-primary/20 border-l-2 border-primary' : 'border-l-2 border-transparent hover:bg-primary/10'"
                 class="flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors duration-150"
             >
-                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'stats' ? 'text-primary-light' : 'text-white/40'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-4 h-4 flex-shrink-0" :class="activeTab === 'stats' ? 'text-primary-light' : 'text-text-muted'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoing="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                 </svg>
-                <span class="text-sm font-medium" :class="activeTab === 'stats' ? 'text-white' : 'text-white/40'">Statistics</span>
+                <span class="text-sm font-medium" :class="activeTab === 'stats' ? 'text-text' : 'text-text-muted'">Statistics</span>
             </div>
         </div
     </nav>
 
     <!-- Bottom Actions -->
-    <div class="px-3 py-3 border-t border-white/5 space-y-0.5">
+    <div class="px-3 py-3 border-t border-primary/10 space-y-0.5">
         <!-- Export -->
         <button
             @click="showExport = true"
-            class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-accent-muted/70 hover:text-accent-muted hover:bg-white/5 transition-colors duration-150"
+            class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-text-muted hover:text-primary hover:bg-primary/10 transition-colors duration-150"
         >
             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
@@ -73,7 +73,7 @@
         <!-- Settings -->
         <button
             @click="showSettings = true"
-            class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-accent-muted/70 hover:text-accent-muted hover:bg-white/5 transition-colors duration-150"
+            class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left text-text-muted hover:text-primary hover:bg-primary/10 transition-colors duration-150"
         >
             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />

--- a/templates/partials/_stats_tab.html
+++ b/templates/partials/_stats_tab.html
@@ -1,32 +1,32 @@
 <div x-show="activeTab === 'stats'" class="flex-1 overflow-y-auto px-6 py-4 space-y-6">
     <!-- Total Hunts -->
-    <div class="bg-bg-card border border-white/8 rounded-xl p-5" id="stats-overall">
-        <div class="text-xs font-semibold uppercase tracking-widest text-white/30 mb-4">Overall</div>
+    <div class="bg-bg-card rounded-xl p-5" id="stats-overall">
+        <div class="text-xs font-semibold uppercase tracking-widest text-text-muted/50 mb-4">Overall</div>
         <div class="grid grid-cols-2 gap-4">
             <div class="bg-bg-surface rounded-lg p-4 text-center">
                 <div class="text-3xl font-bold text-gold" x-text="hunts.filter(h => h.status === 'completed').length"></div>
-                <div class="text-xs text-white/40 mt-1">Completed</div>
+                <div class="text-xs text-text-muted mt-1">Completed</div>
             </div>
             <div class="bg-bg-surface rounded-lg p-4 text-center">
                 <div class="text-3xl font-bold text-primary-light" x-text="hunts.filter(h => h.status === 'active' || !h.status).length"></div>
-                <div class="text-xs text-white/40 mt-1">Active</div>
+                <div class="text-xs text-text-muted mt-1">Active</div>
             </div>
         </div>
     </div>
 
     <!-- By Game -->
-    <div class="bg-bg-card border border-white/8 rounded-xl p-5" x-show="hunts.length > 0" id="stats-by-game">
-        <div class="text-xs font-semibold uppercase tracking-widest text-white/30 mb-4">By Game</div>
+    <div class="bg-bg-card rounded-xl p-5" x-show="hunts.length > 0" id="stats-by-game">
+        <div class="text-xs font-semibold uppercase tracking-widest text-text-muted/50 mb-4">By Game</div>
         <div class="space-y-2">
             <template x-for="game in [...new Set(hunts.map(h => h.game || 'No Game'))].sort()" :key="game">
-                <div class="flex items-center justify-between py-2 border-b border-white/5 last:border-0" :data-game="game">
-                    <span class="text-sm text-white/70" x-text="game"></span>
+                <div class="flex items-center justify-between py-2 border-b border-primary/10 last:border-0" :data-game="game">
+                    <span class="text-sm text-text-muted" x-text="game"></span>
                     <div class="flex items-center gap-3">
-                        <span class="text-xs text-white/30">
+                        <span class="text-xs text-text-muted/50">
                             <span class="text-gold font-semibold" x-text="hunts.filter(h => (h.game || 'No Game') === game && h.status === 'completed').length"></span>
                             completed
                         </span>
-                        <span class="text-xs text-white/30">
+                        <span class="text-xs text-text-muted/50">
                             <span class="text-primary-light font-semibold" x-text="hunts.filter(h => (h.game || 'No Game') === game && (h.status === 'active' || !h.status)).length"></span>
                             active
                         </span>
@@ -39,7 +39,7 @@
     <!-- Empty State -->
     <div x-show="hunts.length === 0" class="flex flex-col items-center justify-center h-full text-center py-16">
         <div class="text-5xl mb-4">📊</div>
-        <div class="text-white/40 text-sm font-medium">No hunts yet</div>
-        <div class="text-white/20 text-xs mt-1">Add a hunt to start tracking statistics</div>
+        <div class="text-text-muted text-sm font-medium">No hunts yet</div>
+        <div class="text-text-muted/50 text-xs mt-1">Add a hunt to start tracking statistics</div>
     </div>
 </div>


### PR DESCRIPTION
## Summary                                                                                                                 
- Replace white-based color scheme with a cohesive dark palette across all templates                                       
- New bg hierarchy: #2C2A4A (main) -> #1E1C35 (sidebar/surface) -> #252341 (cards)                                           
- Cyan (#7FDEFF) as primary text color; #907AD6 as muted text                                                              
- Card borders changed from white/white-opacity to subtle cyan (border-primary/20)                                         
- Hotkey badges styled with gold tint (bg-gold/10 / border-gold/30) to match counter color                                 
- Gold (#FBBF24) retained for counters and milestone alerts                                                                
- All white and white-opacity color references removed from all 7 template partials                                        
                                                                                                                         
## Test plan                                                                                                               
- [x] All 61 backend unit tests passing                                                                                    
- [x] All 64 E2E tests passing                                                                                             
- [x] CI passing 