### PR TITLE
V1.4.2 dev

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Progress on each version can be tracked via [GitHub Milestones](https://github.c
 
 ---
 
-## Current Release - v1.4.0
+## Current Release - v1.4.1
 Current public release.  
 **Core Features:**  
 - Track multiple concurrent shiny hunts
@@ -33,15 +33,12 @@ Current public release.
 - Per-game hunt breakdowns
 - Statistics overlays (total hunts, game-specific totals)
 - Milestone alerts at shiny odds multiples (1x, 2x, 3x base rate)
+- Remove white card borders
+- Audit and improve overal visual consistency
 
 ---
 
 ## Upcoming Releases
-
-### v1.4.1 - UI Polish
-Update and improve the overall UI of the application
-- Remove white card borders
-- Audit and improve overal visual consistency
 
 ### v1.4.2 - Code Quality
 Improvements to the overall code quality of the application and test suite
@@ -49,7 +46,7 @@ Improvements to the overall code quality of the application and test suite
 - Audit existing E2E selectors
 - Identify and resolve/fix any tests that pass by coincidence
 - Add input validation for overlay elements schema
-- Remove auto-creation of 'main' overlay on startup and update test accordingly
+- Remove autoi-creation of 'main' overlay on startup and update test accordingly
 - Add overlay picker when creating a new hunt
 
 ### v1.4.3 - Data Management
@@ -96,3 +93,4 @@ An optional web platform for sharing hunt history and statistics publicly.
 - **v1.3.0** - Overlay System
 - **v1.3.1** - Testing and CI
 - **v1.4.0** - Statistics
+- **v1.4.1** - UI Polish

--- a/app.py
+++ b/app.py
@@ -143,10 +143,18 @@ def get_hunts():
 def add_hunt():
     data = request.json or {}
 
+    pokemon = data.get("pokemon", "").strip()
+    if not pokemon:
+        return jsonify({"error": "pokemon required"}), 400
+
+    display_name = data.get("displayName", "").strip()
+    if not display_name:
+        return jsonify({"error": "displayName required"}), 400
+
     hunt = {
         "id": str(uuid.uuid4()),
-        "pokemon": data.get("pokemon", ""),
-        "displayName": data.get("displayName", "Unknown"),
+        "pokemon": pokemon,
+        "displayName": display_name,
         "spriteUrl": data.get("spriteUrl") or None,
         "count": 0,
         "encounterRate": data.get("encounterRate") or None,
@@ -189,11 +197,49 @@ def update_hunt(hunt_id):
     for k in allowed:
         if k in data:
             if k == "count":
-                hunt["count"] = max(0, int(data[k]))
+                try:
+                    hunt["count"] = max(0, int(data[k]))
+                except (ValueError, TypeError):
+                    return jsonify({"error": "count must be a number"}), 400
+            elif k == "encounterRate":
+                if data[k] is not None:
+                    try:
+                        val = int(data[k])
+                    except (ValueError, TypeError):
+                        return (
+                            jsonify(
+                                {
+                                    "error": "encounterRate must be a positive integer or null"
+                                }
+                            ),
+                            400,
+                        )
+                    if val <= 0:
+                        return (
+                            jsonify(
+                                {
+                                    "error": "encounterRate must be a positive integer or null"
+                                }
+                            ),
+                            400,
+                        )
+                    hunt[k] = val
+                else:
+                    hunt[k] = None
+            elif k == "displayName":
+                if not isinstance(data[k], str) or not data[k].strip():
+                    return (
+                        jsonify({"error": "displayName must be a non-empty string"}),
+                        400,
+                    )
+                hunt[k] = data[k]
+            elif k in ("game", "notes", "spriteUrl"):
+                if data[k] is not None and not isinstance(data[k], str):
+                    return jsonify({"error": f"{k} must be a string or null"}), 400
+                hunt[k] = data[k]
             elif k in ("hotkey", "hotkeyDecrement"):
                 hunt[k] = data[k] or None
-            else:
-                hunt[k] = data[k]
+
     save_hunts(hunts)
     broadcast(hunts, load_overlays())
     rebuild_hotkeys()
@@ -457,9 +503,29 @@ def get_settings():
 def update_settings():
     data = request.json or {}
     settings = load_settings()
-    for k in {"close_behavior", "mark_found_behavior", "milestone_alerts"}:
-        if k in data:
-            settings[k] = data[k]
+
+    if "close_behavior" in data:
+        if data["close_behavior"] not in ("ask", "minimize", "quit"):
+            return (
+                jsonify(
+                    {"error": "close_behavior must be 'ask', 'minimize', or 'quit'"}
+                ),
+                400,
+            )
+        settings["close_behavior"] = data["close_behavior"]
+
+    if "mark_found_behavior" in data:
+        if data["mark_found_behavior"] not in ("ask", "never"):
+            return (
+                jsonify({"error": "mark_found_behavior must be 'ask' or 'never'"}),
+                400,
+            )
+        settings["mark_found_behavior"] = data["mark_found_behavior"]
+
+    if "milestone_alerts" in data:
+        if not isinstance(data["milestone_alerts"], bool):
+            return jsonify({"error": "milestone_alerts must be a boolean"}), 400
+        settings["milestone_alerts"] = data["milestone_alerts"]
     save_settings(settings)
     return jsonify(settings)
 
@@ -563,14 +629,69 @@ def update_overlay(overlay_id):
     if overlay is None:
         return jsonify({"error": "not found"}), 404
     data = request.json or {}
+
     if "name" in data:
-        overlay["name"] = data["name"].strip()
+        name = data["name"].strip()
+        if not name:
+            return jsonify({"error": "name is required"}), 400
+        overlay["name"] = name
+
     if "hunts" in data:
-        overlay["hunts"] = data["hunts"]
+        hunt_data = data["hunts"]
+        if not isinstance(hunt_data, list):
+            return jsonify({"error": "hunts must be a list"}), 400
+        for entry in hunt_data:
+            if not isinstance(entry.get("huntId"), str) or not isinstance(
+                entry.get("visible"), bool
+            ):
+                return (
+                    jsonify(
+                        {
+                            "error": "each hunt entry must have huntId (string) and visible (boolean)"
+                        }
+                    ),
+                    400,
+                )
+        overlay["hunts"] = hunt_data
+
     if "elements" in data:
-        overlay["elements"] = data["elements"]
+        elements = data["elements"]
+        if not isinstance(elements, dict):
+            return jsonify({"error": "elements must be an object"}), 400
+        ov_type = overlay.get("type", "hunt")
+        if ov_type == "hunt":
+            hunt_keys = {"sprite", "name", "count", "odds"}
+            if set(elements.keys()) != hunt_keys:
+                return (
+                    jsonify(
+                        {
+                            "error": f"hunt overlay elements must contain exactly: {sorted(hunt_keys)}"
+                        }
+                    ),
+                    400,
+                )
+            if not all(isinstance(elements[k], bool) for k in hunt_keys):
+                return (
+                    jsonify({"error": "hunt overlay elements must all be booleans"}),
+                    400,
+                )
+        elif ov_type == "stats":
+            if not isinstance(elements.get("totalCompleted"), bool):
+                return jsonify({"error": "totalCompleted must be a boolean"}), 400
+            if elements.get("breakdown") not in ("completed", "active", None):
+                return (
+                    jsonify(
+                        {"error": "breakdown must be 'completed', 'active', or null"}
+                    ),
+                    400,
+                )
+        overlay["elements"] = elements
+
     if "game" in data:
+        if data["game"] is not None and not isinstance(data["game"], str):
+            return jsonify({"error": "game must be a string or null"}), 400
         overlay["game"] = data["game"]
+
     save_overlays(overlays)
     broadcast(load_hunts(), overlays)
     return jsonify(overlay)

--- a/app.py
+++ b/app.py
@@ -9,17 +9,16 @@ import urllib.request
 import uuid
 from queue import Empty, Queue
 
-from waitress import serve
-
 from flask import (
     Flask,
     Response,
     jsonify,
+    redirect,
     render_template,
     request,
-    redirect,
     stream_with_context,
 )
+from waitress import serve
 
 import store
 import tray
@@ -27,19 +26,18 @@ from hotkeys import PYNPUT_AVAILABLE, rebuild_hotkeys
 from store import (
     GAME_POKEDEX_MAP,
     GAMES_CACHE_DIR,
+    broadcast,
+    broadcast_milestone,
     load_hunts,
     load_overlays,
     load_settings,
     save_hunts,
     save_overlays,
     save_settings,
-    broadcast,
-    broadcast_milestone,
     sse_clients,
     sse_lock,
 )
 from tray import WEBVIEW_AVAILABLE, _on_closing, _setup_tray, _wait_for_server
-
 
 if getattr(sys, "frozen", False):
     _TEMPLATE_DIR = os.path.join(sys._MEIPASS, "templates")
@@ -597,11 +595,7 @@ def add_overlay():
             "name": name,
             "type": "hunt",
             "elements": {"sprite": True, "name": True, "count": True, "odds": False},
-            "hunts": [
-                {"huntId": h["id"], "visible": True}
-                for h in hunts
-                if h.get("status", "active") == "active"
-            ],
+            "hunts": [],
         }
     else:
         overlay = {

--- a/app.py
+++ b/app.py
@@ -61,7 +61,7 @@ def control_panel():
 
 @app.route("/overlay")
 def overlay_default():
-    return redirect("/overlay/main")
+    return "", 404
 
 
 @app.route("/overlay/<name>")
@@ -506,21 +506,6 @@ def migrate_overlays() -> None:
     if changed:
         save_hunts(hunts)
         save_overlays(overlays)
-    if overlays:
-        return
-    overlay = {
-        "id": str(uuid.uuid4()),
-        "name": "main",
-        "type": "hunt",
-        "elements": {
-            "sprite": True,
-            "name": True,
-            "count": True,
-            "odds": False,
-        },
-        "hunts": [{"huntId": h["id"], "visible": True} for h in hunts],
-    }
-    save_overlays([overlay])
 
 
 @app.get("/api/overlays")

--- a/static/app.js
+++ b/static/app.js
@@ -15,7 +15,7 @@ function app() {
     markFoundNotes: "",
     showExport: false,
     acHighlight: -1,
-    newHunt: { name: "", game: "", error: "", loading: false },
+    newHunt: { name: "", game: "", error: "", loading: false, overlayIds: [], newOverlayName: '', showNewOverlay: false, showOverlayPicker: false },
     capture: { huntId: null, field: null },
     settings: { close_behavior: "ask", mark_found_behavior: "ask" },
     showCloseDialog: false,
@@ -104,10 +104,12 @@ function app() {
 
     // Hunt operations
     async addHunt() {
-      const name = this.newHunt.name.trim();
+      const name = this.newHunt.name.trim()
       if (!name) return;
+
       this.newHunt.loading = true;
-      this.newHunt.error = "";
+      this.newHunt.error = '';
+
       try {
         const pokemon = await fetch(`/api/pokemon/${encodeURIComponent(name)}`).then(
           (r) => r.json(),
@@ -116,20 +118,35 @@ function app() {
           this.newHunt.error = pokemon.error;
           return;
         }
-        await fetch("/api/hunts", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
+
+        const hunt = await fetch('/api/hunts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             pokemon: pokemon.pokemon,
             displayName: pokemon.displayName,
             spriteUrl: pokemon.spriteUrl,
             game: this.newHunt.game || null,
           }),
-        });
-        this.newHunt.name = "";
+        }).then((r) => r.json());
+
+        for (const overlayId of this.newHunt.overlayIds) {
+          const overlay = this.overlays.find((o) => o.id === overlayId);
+          if (!overlay) continue;
+          await fetch(`/api/overlays/${overlayId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              hunts: [...overlay.hunts, { huntId: hunt.id, visible: true }],
+            }),
+          });
+        }
+        this.newHunt.name = '';
+        this.newHunt.overlayIds = [];
+        this.newHunt.showOverlayPicker = false;
         this.acOptions = [];
       } catch {
-        this.newHunt.error = "Failed to add hunt";
+        this.newHunt.error = 'Failed to add hunt';
       } finally {
         this.newHunt.loading = false;
       }
@@ -365,6 +382,43 @@ function app() {
       });
       this.newOverlayName = "";
       this.showNewOverlay = false;
+    },
+
+    async addOverlayFromForm() {
+      const name = this.newHunt.newOverlayName.trim();
+      if (!name) return;
+      const overlay = await fetch('/api/overlays', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, type: 'hunt' }),
+      }).then((r) => r.json());
+      this.overlays = [...this.overlays, overlay];
+      this.newHunt.overlayIds = [...this.newHunt.overlayIds, overlay.id];
+      this.newHunt.newOverlayName = '';
+      this.newHunt.showNewOverlay = false;
+    },
+
+    newHuntOverlayLabel() {
+      if (this.newHunt.overlayIds.length === 0) return 'No overlay';
+      if (this.newHunt.overlayIds.length === 1) {
+        const overlay = this.overlays.find((o) => o.id === this.newHunt.overlayIds[0]);
+        return overlay ? overlay.name : '1 overlay';
+      }
+      return `${this.newHunt.overlayIds.length} overlays`;
+    },
+
+    huntOverlaysAllSelected() {
+      const huntOverlays = this.overlays.filter((o) => (o.type || 'hunt') === 'hunt');
+      return huntOverlays.length > 0 && huntOverlays.every((o) => this.newHunt.overlayIds.includes(o.id));
+    },
+
+    toggleSelectAllOverlays() {
+      const huntOverlays = this.overlays.filter((o) => (o.type || 'hunt') === 'hunt');
+      if (this.huntOverlaysAllSelected()) {
+        this.newHunt.overlayIds = [];
+      } else {
+        this.newHunt.overlayIds = huntOverlays.map((o) => o.id);
+      }
     },
 
     async deleteOverlay(id) {

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -694,6 +694,14 @@ video {
   height: 100vh;
 }
 
+.h-3 {
+  height: 0.75rem;
+}
+
+.max-h-40 {
+  max-height: 10rem;
+}
+
 .w-10 {
   width: 2.5rem;
 }
@@ -740,6 +748,10 @@ video {
 
 .w-full {
   width: 100%;
+}
+
+.w-3 {
+  width: 0.75rem;
 }
 
 .min-w-0 {
@@ -875,6 +887,10 @@ video {
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.whitespace-nowrap {
   white-space: nowrap;
 }
 
@@ -1288,6 +1304,14 @@ video {
 
 .placeholder-text-muted\/60::placeholder {
   color: rgb(144 122 214 / 0.6);
+}
+
+.placeholder-text-muted\/40::-moz-placeholder {
+  color: rgb(144 122 214 / 0.4);
+}
+
+.placeholder-text-muted\/40::placeholder {
+  color: rgb(144 122 214 / 0.4);
 }
 
 .accent-primary {

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -670,6 +670,10 @@ video {
   height: 3rem;
 }
 
+.h-3 {
+  height: 0.75rem;
+}
+
 .h-3\.5 {
   height: 0.875rem;
 }
@@ -694,10 +698,6 @@ video {
   height: 100vh;
 }
 
-.h-3 {
-  height: 0.75rem;
-}
-
 .max-h-40 {
   max-height: 10rem;
 }
@@ -712,6 +712,10 @@ video {
 
 .w-20 {
   width: 5rem;
+}
+
+.w-3 {
+  width: 0.75rem;
 }
 
 .w-3\.5 {
@@ -748,10 +752,6 @@ video {
 
 .w-full {
   width: 100%;
-}
-
-.w-3 {
-  width: 0.75rem;
 }
 
 .min-w-0 {
@@ -1290,6 +1290,14 @@ video {
   color: rgb(144 122 214 / 0.3);
 }
 
+.placeholder-text-muted\/40::-moz-placeholder {
+  color: rgb(144 122 214 / 0.4);
+}
+
+.placeholder-text-muted\/40::placeholder {
+  color: rgb(144 122 214 / 0.4);
+}
+
 .placeholder-text-muted\/50::-moz-placeholder {
   color: rgb(144 122 214 / 0.5);
 }
@@ -1304,14 +1312,6 @@ video {
 
 .placeholder-text-muted\/60::placeholder {
   color: rgb(144 122 214 / 0.6);
-}
-
-.placeholder-text-muted\/40::-moz-placeholder {
-  color: rgb(144 122 214 / 0.4);
-}
-
-.placeholder-text-muted\/40::placeholder {
-  color: rgb(144 122 214 / 0.4);
 }
 
 .accent-primary {

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -990,16 +990,16 @@ video {
   background-color: rgb(127 222 255 / 0.2);
 }
 
+.bg-primary\/25 {
+  background-color: rgb(127 222 255 / 0.25);
+}
+
 .bg-primary\/30 {
   background-color: rgb(127 222 255 / 0.3);
 }
 
 .bg-transparent {
   background-color: transparent;
-}
-
-.bg-primary\/25 {
-  background-color: rgb(127 222 255 / 0.25);
 }
 
 .object-contain {
@@ -1361,12 +1361,12 @@ video {
   background-color: rgb(127 222 255 / 0.3);
 }
 
-.hover\:bg-primary\/5:hover {
-  background-color: rgb(127 222 255 / 0.05);
-}
-
 .hover\:bg-primary\/40:hover {
   background-color: rgb(127 222 255 / 0.4);
+}
+
+.hover\:bg-primary\/5:hover {
+  background-color: rgb(127 222 255 / 0.05);
 }
 
 .hover\:text-danger:hover {

--- a/templates/partials/_add_hunt_form.html
+++ b/templates/partials/_add_hunt_form.html
@@ -36,7 +36,7 @@
         </div>
         <!-- Game (optional) -->
         <div>
-            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider">Game <span class="text-text-muted/50 normal-case tracking-normal">(optional)</span></label>
+            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider ">Game <span class="text-text-muted/50 mormal-case tracking-normal">(optional)</span></label>
             <select
                 x-model="newHunt.game"
                 @change="onGameChange()"
@@ -47,6 +47,94 @@
                     <option :value="game" x-text="game"></option>
                 </template>
             </select>
+        </div>
+        <!-- Overlay Picker -->
+        <div class="relative" @click.outside="newHunt.showOverlayPicker = false">
+            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider">Overlay <span class="text-text-muted/50 normal-case tracking-normal">(optional)</span></label>
+            <button
+                type="button"
+                data-testid="overlay-picker-trigger"
+                @click="newHunt.showOverlayPicker = !newHunt.showOverlayPicker"
+                class="flex items-center gap-2 bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-primary/60 transition-colors duration-150 cursor-pointer whitespace-nowrap"
+            >
+                <span x-text="newHuntOverlayLabel()"></span>
+                <svg class="w-3.5 h-3.5 text-text-muted/50 transition-transform duration-150" :class="newHunt.showOverlayPicker ? 'rotat-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+            <!-- Popover -->
+            <div
+                x-show="newHunt.showOverlayPicker"
+                class="absolute top-full left-0 mt-1 w-56 bg-bg-card border border-primary/20 rounded-lg shadow-xl z-50 overflow-hidden"
+            >
+                <!-- Select All -->
+                <div
+                    x-show="overlays.filter(o => (o.type || 'hunt') === 'hunt').length > 0"
+                    class="px-3 py-2 border-b border-primary/10"
+                >
+                    <label class="flex items-center gap-2 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            data-testid="select-all-overlays"
+                            :checked="huntOverlaysAllSelected()"
+                            @change="toggleSelectAllOverlays()"
+                            class="accent-primary"
+                        />
+                        <span class="text-xs text-text-muted">Select All</span>
+                    </label>
+                </div>
+                <!-- Overlay List -->
+                <div class="max-h-40 overflow-y-auto">
+                    <template x-if="overlays.filter(o => (o.type || 'hunt') === 'hunt').length === 0">
+                        <div class="px-3 py-2 text-xs text-text-muted/50">No overlays yet</div>
+                    </template>
+                    <template x-for="overlay in overlays.filter(o => (o.type || 'hunt') === 'hunt')" :key="overlay.id">
+                        <label class="flex items-center gap-2 px-3 py-1.5 cursor-pointer hover:bg-primary/5" :dats-overlay-id="overlay.id">
+                            <input
+                                type="checkbox"
+                                :value="overlay.id"
+                                x-model="newHunt.overlayIds"
+                                class="accent-primary"
+                            />
+                            <span class="text-xs text-text" x-text="overlay.name"></span>
+                        </label>
+                    </template>
+                </div>
+                <!-- New Overlay -->
+                <div class="border-t border-primary/10 px-3 py-2">
+                    <div x-show="!newHunt.showNewOverlay">
+                        <button
+                            @click.stop="newHunt.showNewOverlay = true"
+                            class="flex items-center gap-1.5 text-xs text-text-muted/50 hover:text-text-muted transition-colors duration-150"
+                        >
+                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                            </svg>
+                            New Overlay
+                        </button>
+                    </div>
+                    <div x-show="newHunt.showNewOverlay" class="flex items-center gap-1.5">
+                        <input
+                            type="text"
+                            x-model="newHunt.newOverlayName"
+                            @keydown.enter.prevent="addOverlayFromForm()"
+                            @keydown.escape="newHunt.showNewOverlay = false; newHunt.newOverlayName = ''"
+                            placeholder="Overlay name..."
+                            data-testid="new-overlay-name-input"
+                            class="flex-1 bg-bg-surface border border-primary/20 rounded px-2 py-1 text-xs text-text placeholder-text-muted/40 focus:outline-none focus:border-primary/60 transition-colors duration-150"
+                        />
+                        <button
+                            @click.stop="addOverlayFromForm()"
+                            data-testid="add-overlay-from-form"
+                            class="text-xs px-2 py-1 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded text-text transition-colors duration-150"
+                        >Add</button>
+                        <button
+                            @click.stop="newHunt.showNewOverlay = false; newHunt.newOverlayName = ''"
+                            class="text-xs text-text-muted/50 hover:tetx-text-muted transition-colors duration-150"
+                        >✕</button>
+                    </div>
+                </div>
+            </div>
         </div>
         <!-- Add Button -->
         <button

--- a/templates/partials/_add_hunt_form.html
+++ b/templates/partials/_add_hunt_form.html
@@ -1,8 +1,14 @@
-<div x-show="activeTab === 'hunts'" class="px-6 py-4 border-b border-primary/10 bg-bg-surface/50">
+<div
+    x-show="activeTab === 'hunts'"
+    class="px-6 py-4 border-b border-primary/10 bg-bg-surface/50"
+>
     <div class="flex items-end gap-3">
         <!-- Pokemon Search -->
         <div class="flex-1 max-w-xs">
-            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider">Pokemon</label>
+            <label
+                class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider"
+                >Pokemon</label
+            >
             <div class="relative">
                 <input
                     type="text"
@@ -23,7 +29,10 @@
                     x-show="acOptions.length > 0"
                     class="absolute top-full left-0 right-0 mt-1 bg-bg-card border border-primary/20 rounded-lg overflow-hidden z-50 shadow-xl"
                 >
-                    <template x-for="(option, index) in acOptions" :key="option">
+                    <template
+                        x-for="(option, index) in acOptions"
+                        :key="option"
+                    >
                         <div
                             @mousedown.prevent="selectAc(option)"
                             :class="index === acHighlight ? 'bg-primary/30 text-text' : 'text-text-muted hover:bg-primary/10'"
@@ -36,8 +45,15 @@
         </div>
         <!-- Game (optional) -->
         <div>
-            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider ">Game <span class="text-text-muted/50 mormal-case tracking-normal">(optional)</span></label>
+            <label
+                class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider"
+                >Game
+                <span class="text-text-muted/50 normal-case tracking-normal"
+                    >(optional)</span
+                ></label
+            >
             <select
+                data-testid="add-hunt-game-select"
                 x-model="newHunt.game"
                 @change="onGameChange()"
                 class="bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-primary/60 transition-colors duration-150 cursor-pointer"
@@ -49,8 +65,17 @@
             </select>
         </div>
         <!-- Overlay Picker -->
-        <div class="relative" @click.outside="newHunt.showOverlayPicker = false">
-            <label class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider">Overlay <span class="text-text-muted/50 normal-case tracking-normal">(optional)</span></label>
+        <div
+            class="relative"
+            @click.outside="newHunt.showOverlayPicker = false"
+        >
+            <label
+                class="block text-xs font-medium text-text-muted mb-1.5 uppercase tracking-wider"
+                >Overlay
+                <span class="text-text-muted/50 normal-case tracking-normal"
+                    >(optional)</span
+                ></label
+            >
             <button
                 type="button"
                 data-testid="overlay-picker-trigger"
@@ -58,13 +83,25 @@
                 class="flex items-center gap-2 bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-primary/60 transition-colors duration-150 cursor-pointer whitespace-nowrap"
             >
                 <span x-text="newHuntOverlayLabel()"></span>
-                <svg class="w-3.5 h-3.5 text-text-muted/50 transition-transform duration-150" :class="newHunt.showOverlayPicker ? 'rotat-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                <svg
+                    class="w-3.5 h-3.5 text-text-muted/50 transition-transform duration-150"
+                    :class="newHunt.showOverlayPicker ? 'rotate-180' : ''"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 9l-7 7-7-7"
+                    />
                 </svg>
             </button>
             <!-- Popover -->
             <div
                 x-show="newHunt.showOverlayPicker"
+                data-testid="overlay-picker-popover"
                 class="absolute top-full left-0 mt-1 w-56 bg-bg-card border border-primary/20 rounded-lg shadow-xl z-50 overflow-hidden"
             >
                 <!-- Select All -->
@@ -85,18 +122,31 @@
                 </div>
                 <!-- Overlay List -->
                 <div class="max-h-40 overflow-y-auto">
-                    <template x-if="overlays.filter(o => (o.type || 'hunt') === 'hunt').length === 0">
-                        <div class="px-3 py-2 text-xs text-text-muted/50">No overlays yet</div>
+                    <template
+                        x-if="overlays.filter(o => (o.type || 'hunt') === 'hunt').length === 0"
+                    >
+                        <div class="px-3 py-2 text-xs text-text-muted/50">
+                            No overlays yet
+                        </div>
                     </template>
-                    <template x-for="overlay in overlays.filter(o => (o.type || 'hunt') === 'hunt')" :key="overlay.id">
-                        <label class="flex items-center gap-2 px-3 py-1.5 cursor-pointer hover:bg-primary/5" :dats-overlay-id="overlay.id">
+                    <template
+                        x-for="overlay in overlays.filter(o => (o.type || 'hunt') === 'hunt')"
+                        :key="overlay.id"
+                    >
+                        <label
+                            class="flex items-center gap-2 px-3 py-1.5 cursor-pointer hover:bg-primary/5"
+                            :data-overlay-id="overlay.id"
+                        >
                             <input
                                 type="checkbox"
                                 :value="overlay.id"
                                 x-model="newHunt.overlayIds"
                                 class="accent-primary"
                             />
-                            <span class="text-xs text-text" x-text="overlay.name"></span>
+                            <span
+                                class="text-xs text-text"
+                                x-text="overlay.name"
+                            ></span>
                         </label>
                     </template>
                 </div>
@@ -105,33 +155,51 @@
                     <div x-show="!newHunt.showNewOverlay">
                         <button
                             @click.stop="newHunt.showNewOverlay = true"
+                            data-testid="show-new-overlay-form"
                             class="flex items-center gap-1.5 text-xs text-text-muted/50 hover:text-text-muted transition-colors duration-150"
                         >
-                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                            <svg
+                                class="w-3 h-3"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                            >
+                                <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M12 4v16m8-8H4"
+                                />
                             </svg>
                             New Overlay
                         </button>
                     </div>
-                    <div x-show="newHunt.showNewOverlay" class="flex items-center gap-1.5">
+                    <div
+                        x-show="newHunt.showNewOverlay"
+                        class="flex items-center gap-1.5"
+                    >
                         <input
                             type="text"
                             x-model="newHunt.newOverlayName"
                             @keydown.enter.prevent="addOverlayFromForm()"
                             @keydown.escape="newHunt.showNewOverlay = false; newHunt.newOverlayName = ''"
-                            placeholder="Overlay name..."
+                            placeholder="New overlay name..."
                             data-testid="new-overlay-name-input"
-                            class="flex-1 bg-bg-surface border border-primary/20 rounded px-2 py-1 text-xs text-text placeholder-text-muted/40 focus:outline-none focus:border-primary/60 transition-colors duration-150"
+                            class="min-w-0 flex-1 bg-bg-surface border border-primary/20 rounded px-2 py-1 text-xs text-text placeholder-text-muted/40 focus:outline-none focus:border-primary/60 transition-colors duration-150"
                         />
                         <button
                             @click.stop="addOverlayFromForm()"
                             data-testid="add-overlay-from-form"
                             class="text-xs px-2 py-1 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded text-text transition-colors duration-150"
-                        >Add</button>
+                        >
+                            Add
+                        </button>
                         <button
                             @click.stop="newHunt.showNewOverlay = false; newHunt.newOverlayName = ''"
-                            class="text-xs text-text-muted/50 hover:tetx-text-muted transition-colors duration-150"
-                        >✕</button>
+                            class="text-xs text-text-muted/50 hover:text-text-muted transition-colors duration-150"
+                        >
+                            ✕
+                        </button>
                     </div>
                 </div>
             </div>
@@ -142,8 +210,18 @@
             :disabled="newHunt.loading || !newHunt.name.trim()"
             class="flex items-center gap-2 px-4 py-2 border border-primary/30 bg-primary/25 hover:bg-primary/40 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg text-sm font-semibold text-text transition-colors duration-150"
         >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            <svg
+                class="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 4v16m8-8H4"
+                />
             </svg>
             <span x-text="newHunt.loading ? 'Adding...' : 'Add Hunt'"></span>
         </button>

--- a/templates/partials/_history_tab.html
+++ b/templates/partials/_history_tab.html
@@ -10,7 +10,7 @@
     </div>
     <!-- Completed Hunt Cards -->
     <template x-for="hunt in hunts.filter(h => h.status === 'completed')" :key="hunt.id">
-        <div class="bg-bg-card rounded-xl p-4 flex items-center gap-4 transition-colors duration-150">
+        <div :data-hunt-id="hunt.id" class="bg-bg-card rounded-xl p-4 flex items-center gap-4 transition-colors duration-150">
             <!-- Sprite -->
             <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center">
                 <template x-if="hunt.spriteUrl">
@@ -35,7 +35,7 @@
                 <div x-show="hunt.notes" class="mt-1 text-xs text-text-muted italic truncate" x-text="hunt.notes"></div>
             </div>
             <!-- Final Count -->
-            <div class="flex-shrink-0 text-gold font-bold text-lg tabular-nums" x-text="hunt.count.toLocaleString('en-US')"></div>
+            <div data-testid="final-count" class="flex-shrink-0 text-gold font-bold text-lg tabular-nums" x-text="hunt.count.toLocaleString('en-US')"></div>
             <!-- Delete -->
             <button
                 @click="deleteHunt(hunt.id)"

--- a/templates/partials/_hunts_tab.html
+++ b/templates/partials/_hunts_tab.html
@@ -10,7 +10,7 @@
     </div>
     <!-- Hunt Cards -->
     <template x-for="hunt in hunts.filter(h => h.status === 'active' || !h.status)" :key="hunt.id">
-        <div class="bg-bg-card rounded-xl p-4 flex items-center gap-4 transition-colors duration-150">
+        <div :data-hunt-id="hunt.id" class="bg-bg-card rounded-xl p-4 flex items-center gap-4 transition-colors duration-150">
             <!-- Sprite -->
             <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center">
                 <template x-if="hunt.spriteUrl">
@@ -55,13 +55,14 @@
                     <template x-if="!(capture.huntId === hunt.id && capture.field === 'hotkey')">
                         <div class="flex items-center gap-1">
                             <template x-if="hunt.hotkey">
-                                <span class="px-1.5 py-0.5 bg-gold/10 border border-gold/30 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkey)"></span>
+                                <span data-testid="badge-hotkey" class="px-1.5 py-0.5 bg-gold/10 border border-gold/30 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkey)"></span>
                             </template>
                             <template x-if="hunt.hotkey">
                                 <button @click="clearHotkey(hunt.id, 'hotkey')" title="Clear increment hotkey" class="text-text-muted/50 hover:text-danger transition-colors text-xs">✕</button>
                             </template>
                             <button
                                 @click="startCapture(hunt.id, 'hotkey')"
+                                title="Edit increment hotkey"
                                 class="px-2 py-0.5 bg-bg-surface border border-primary/20 hover:border-primary rounded text-xs text-text-muted hover:text-text transition-colors duration-150"
                                 x-text="hunt.hotkey ? 'Change' : 'Set'"
                             ></button>
@@ -80,13 +81,14 @@
                     <template x-if="!(capture.huntId === hunt.id && capture.field === 'hotkeyDecrement')">
                         <div class="flex items-center gap-1">
                             <template x-if="hunt.hotkeyDecrement">
-                                <span class="px-1.5 py-0.5 bg-gold/10 border border-gold/30 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkeyDecrement)"></span>
+                                <span data-testid="badge-hotkey-decrement" class="px-1.5 py-0.5 bg-gold/10 border border-gold/30 rounded text-xs text-gold font-mono" x-text="formatHotkey(hunt.hotkeyDecrement)"></span>
                             </template>
                             <template x-if="hunt.hotkeyDecrement">
                                 <button @click="clearHotkey(hunt.id, 'hotkeyDecrement')" title="Clear decrement hotkey" class="text-text-muted/50 hover:text-danger transition-colors text-xs">✕</button>
                             </template>
                             <button
                                 @click="startCapture(hunt.id, 'hotkeyDecrement')"
+                                title="Edit decrement hotkey"
                                 class="px-2 py-0.5 bg-bg-surface border border-primary/20 hover:border-primary rounded text-xs text-text-muted hover:text-text transition-colors duration-150"
                                 x-text="hunt.hotkeyDecrement ? 'Change' : 'Set'"
                             ></button>
@@ -98,16 +100,19 @@
             <div class="flex-shrink-0 flex items-center gap-1.5">
                 <button
                     @click="decrement(hunt.id)"
+                    title="Decrement"
                     class="w-7 h-7 flex items-center justify-center rounded-lg bg-bg-surface border border-primary/20 hover:border-primary hover:bg-primary/10 text-text-muted hover:text-text transition-colors duration-150 text-lg leading-none"
                 >-</button>
                 <input
                     type="number"
                     :value="hunt.count"
                     @change="setCount(hunt.id, $event.target.value)"
+                    data-testid="count-input"
                     class="w-20 text-center bg-transparent text-gold font-bold text-lg tabular-nums focus:outline-none focus:bg-bg-surface rounded px-1"
                 />
                 <button
                     @click="increment(hunt.id)"
+                    title="Increment"
                     class="w-7 h-7 flex items-center justify-center rounded-lg bg-bg-surface border border-primary/20 hover:border-primary hover:bg-primary/10 text-text-muted hover:text-text transition-colors duration-150 text-lg leading-none"
                 >+</button>
             </div>

--- a/templates/partials/_modals.html
+++ b/templates/partials/_modals.html
@@ -2,25 +2,37 @@
 <div
     x-show="showCloseDialog"
     x-transition.opacity
-    style="z-index: 60;"
+    style="z-index: 60"
     class="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm"
 >
-    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-80 shadow-2xl">
-        <div class="text-base font-semibold text-text mb-1">Close Shiny Trak?</div>
-        <div class="text-sm text-text-muted mb-5">What would you like to do?</div>
+    <div
+        class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-80 shadow-2xl"
+    >
+        <div class="text-base font-semibold text-text mb-1">
+            Close Shiny Trak?
+        </div>
+        <div class="text-sm text-text-muted mb-5">
+            What would you like to do?
+        </div>
         <div class="flex flex-col gap-2">
             <button
                 @click="confirmClose('minimize')"
                 class="w-full px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text text-left transition-colors duration-150"
-            >Minimize to tray</button>
+            >
+                Minimize to tray
+            </button>
             <button
                 @click="confirmClose('quit')"
                 class="w-full px-4 py-2.5 bg-danger/10 hover:bg-danger/20 border border-danger/20 rounded-lg text-sm font-medium text-danger text-left transition-colors duration-150"
-            >Quit Shiny Trak</button>
+            >
+                Quit Shiny Trak
+            </button>
             <button
                 @click="confirmClose('cancel')"
                 class="w-full px-4 py-2.5 hover:bg-primary/10 rounded-lg text-sm font-medium text-text-muted hover:text-text-muted text-left transition-colors duration-150"
-            >Cancel</button>
+            >
+                Cancel
+            </button>
         </div>
     </div>
 </div>
@@ -31,21 +43,45 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     @click.self="showSettings = false"
 >
-    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl">
+    <div
+        class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl"
+    >
         <div class="flex items-center justify-between mb-5">
             <div class="text-base font-semibold text-text">Settings</div>
-            <button @click="showSettings = false" class="text-text-muted/50 hover:text-text-muted transition-colors">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            <button
+                @click="showSettings = false"
+                class="text-text-muted/50 hover:text-text-muted transition-colors"
+            >
+                <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M6 18L18 6M6 6l12 12"
+                    />
                 </svg>
             </button>
         </div>
         <!-- Close Behavior -->
         <div>
-            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">When closing the window</div>
+            <div
+                class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3"
+            >
+                When closing the window
+            </div>
             <div class="space-y-1.5">
-                <template x-for="opt in [{value:'ask',label:'Ask every time'},{value:'minimize',label:'Minimize to tray'},{value:'quit',label:'Quit'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
+                <template
+                    x-for="opt in [{value:'ask',label:'Ask every time'},{value:'minimize',label:'Minimize to tray'},{value:'quit',label:'Quit'}]"
+                    :key="opt.value"
+                >
+                    <label
+                        class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150"
+                    >
                         <input
                             type="radio"
                             name="close_behavior"
@@ -54,17 +90,29 @@
                             @change="saveSettings()"
                             class="accent-primary"
                         />
-                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
+                        <span
+                            class="text-sm text-text-muted"
+                            x-text="opt.label"
+                        ></span>
                     </label>
                 </template>
             </div>
         </div>
         <!-- Mark Found Behavior -->
         <div class="mt-5 pt-5 border-t border-primary/10">
-            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">When marking a hunt as found</div>
+            <div
+                class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3"
+            >
+                When marking a hunt as found
+            </div>
             <div class="space-y-1.5">
-                <template x-for="opt in [{value:'ask',label:'Ask for notes'},{value:'never',label:'Complete immediately'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
+                <template
+                    x-for="opt in [{value:'ask',label:'Ask for notes'},{value:'never',label:'Complete immediately'}]"
+                    :key="opt.value"
+                >
+                    <label
+                        class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150"
+                    >
                         <input
                             type="radio"
                             name="mark_found_behavior"
@@ -73,22 +121,33 @@
                             @change="saveSettings()"
                             class="accent-primary"
                         />
-                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
+                        <span
+                            class="text-sm text-text-muted"
+                            x-text="opt.label"
+                        ></span>
                     </label>
                 </template>
             </div>
         </div>
         <!-- Milestone Alerts -->
         <div class="mt-5 pt-5 border-t border-primary/10">
-            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Milestone Alerts</div>
-            <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
+            <div
+                class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3"
+            >
+                Milestone Alerts
+            </div>
+            <label
+                class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150"
+            >
                 <input
                     type="checkbox"
                     x-model="settings.milestone_alerts"
                     @change="saveSettings()"
                     class="accent-primary"
                 />
-                <span class="text-sm text-text-muted">Show alerts when a hunt reaches 1x, 2x, 3x odds</span>
+                <span class="text-sm text-text-muted"
+                    >Show alerts when a hunt reaches 1x, 2x, 3x odds</span
+                >
             </label>
         </div>
     </div>
@@ -100,37 +159,69 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     @click.self="showMarkFound = false"
 >
-    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl">
+    <div
+        class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl"
+    >
         <div class="flex items-center justify-between mb-5">
             <div>
-                <div class="text-base font-semibold text-text">Mark as Found</div>
-                <div class="text-sm text-text-muted mt-0.5" x-text="markFoundHunt ? markFoundHunt.displayName : ''"></div>
+                <div class="text-base font-semibold text-text">
+                    Mark as Found
+                </div>
+                <div
+                    class="text-sm text-text-muted mt-0.5"
+                    x-text="markFoundHunt ? markFoundHunt.displayName : ''"
+                ></div>
             </div>
-            <button @click="showMarkFound = false" class="text-text-muted/50 hover:text-text-muted transition-colors">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            <button
+                @click="showMarkFound = false"
+                class="text-text-muted/50 hover:text-text-muted transition-colors"
+            >
+                <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M6 18L18 6M6 6l12 12"
+                    />
                 </svg>
             </button>
         </div>
         <!-- Notes -->
         <div class="mb-5">
-            <label class="block text-xs font-medium text-text-muted uppercase tracking-wider mb-1.5">Notes <span class="text-text-muted/50 normal-case tracking-normal">(optional)</span></label>
+            <label
+                class="block text-xs font-medium text-text-muted uppercase tracking-wider mb-1.5"
+                >Notes
+                <span class="text-text-muted/50 normal-case tracking-normal"
+                    >(optional)</span
+                ></label
+            >
             <textarea
                 x-model="markFoundNotes"
                 placeholder="How did you find it? Any thoughts..."
                 rows="3"
-                class="w-full bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text placeholder-text-muted/30 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors duration-150 resize-none"></textarea>
+                class="w-full bg-bg-card border border-primary/20 rounded-lg px-3 py-2 text-sm text-text placeholder-text-muted/30 focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors duration-150 resize-none"
+            ></textarea>
         </div>
         <!-- Actions -->
         <div class="flex gap-2">
             <button
                 @click="confirmMarkFound()"
+                data-testid="confirm-mark-found"
                 class="flex-1 px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150"
-            >Mark as Found</button>
+            >
+                Mark as Found
+            </button>
             <button
                 @click="showMarkFound = false"
                 class="px-4 py-2.5 hover:bg-primary/10 rounded-lg text-sm font-medium text-text-muted hover:text-text-muted transition-colors duration-150"
-            >Cancel</button>
+            >
+                Cancel
+            </button>
         </div>
     </div>
 </div>
@@ -141,35 +232,86 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     @click.self="showExport = false"
 >
-    <div class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl">
+    <div
+        class="bg-bg-surface border border-primary/20 rounded-2xl p-6 w-96 shadow-2xl"
+    >
         <div class="flex items-center justify-between mb-5">
             <div class="text-base font-semibold text-text">Export Hunts</div>
-            <button @click="showExport = false" class="text-text-muted/50 hover:text-text-muted transition-colors">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            <button
+                @click="showExport = false"
+                class="text-text-muted/50 hover:text-text-muted transition-colors"
+            >
+                <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M6 18L18 6M6 6l12 12"
+                    />
                 </svg>
             </button>
         </div>
         <!-- Scope -->
         <div class="mb-5">
-            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Include</div>
+            <div
+                class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3"
+            >
+                Include
+            </div>
             <div class="space-y-1.5">
-                <template x-for="opt in [{value:'all',label:'All hunts'},{value:'active',label:'Active hunts only'},{value:'completed',label:'Completed hunts only'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
-                        <input type="radio" name="export_scope" :value="opt.value" x-model="exportScope" class="accent-primary" />
-                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
+                <template
+                    x-for="opt in [{value:'all',label:'All hunts'},{value:'active',label:'Active hunts only'},{value:'completed',label:'Completed hunts only'}]"
+                    :key="opt.value"
+                >
+                    <label
+                        class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150"
+                    >
+                        <input
+                            type="radio"
+                            name="export_scope"
+                            :value="opt.value"
+                            x-model="exportScope"
+                            class="accent-primary"
+                        />
+                        <span
+                            class="text-sm text-text-muted"
+                            x-text="opt.label"
+                        ></span>
                     </label>
                 </template>
             </div>
         </div>
         <!-- Format -->
         <div class="mb-5">
-            <div class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3">Format</div>
+            <div
+                class="text-xs font-medium text-text-muted uppercase tracking-wider mb-3"
+            >
+                Format
+            </div>
             <div class="space-y-1.5">
-                <template x-for="opt in [{value:'json',label:'JSON'},{value:'csv',label:'CSV'}]" :key="opt.value">
-                    <label class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150">
-                        <input type="radio" name="export_format" :value="opt.value" x-model="exportFormat" class="accent-primary" />
-                        <span class="text-sm text-text-muted" x-text="opt.label"></span>
+                <template
+                    x-for="opt in [{value:'json',label:'JSON'},{value:'csv',label:'CSV'}]"
+                    :key="opt.value"
+                >
+                    <label
+                        class="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-primary/10 cursor-pointer transition-colors duration-150"
+                    >
+                        <input
+                            type="radio"
+                            name="export_format"
+                            :value="opt.value"
+                            x-model="exportFormat"
+                            class="accent-primary"
+                        />
+                        <span
+                            class="text-sm text-text-muted"
+                            x-text="opt.label"
+                        ></span>
                     </label>
                 </template>
             </div>
@@ -178,18 +320,30 @@
         <button
             @click="exportHunts(exportScope, exportFormat);"
             class="w-full px-4 py-2.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150"
-        >Download</button>
+        >
+            Download
+        </button>
     </div>
 </div>
 <!-- Toast Notification -->
 <div
     x-show="exportMessage"
     x-transition.opacity
-    style="z-index: 70;"
+    style="z-index: 70"
     class="fixed bottom-5 right-5 bg-bg-surface border border-primary/20 rounded-xl px-4 py-3 shadow-2xl flex items-center gap-3"
 >
-    <svg class="w-4 h-4 text-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+    <svg
+        class="w-4 h-4 text-primary flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+    >
+        <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M5 13l4 4L19 7"
+        />
     </svg>
     <span class="text-sm text-text-muted" x-text="exportMessage"></span>
 </div>
@@ -197,7 +351,7 @@
 <div
     x-show="milestoneAlert"
     x-transition.opacity
-    style="z-index: 70;"
+    style="z-index: 70"
     class="fixed top-5 left-1/2 -translate-x-1/2 bg-bg-surface border border-yellow-400/40 rounded-xl px-5 py-3 shadow-2xl flex items-center gap-3 pointer-events-none"
 >
     <span class="text-lg">✨</span>

--- a/templates/partials/_overlays_tab.html
+++ b/templates/partials/_overlays_tab.html
@@ -1,23 +1,31 @@
-<div x-show="activeTab === 'overlays'" class="flex-1 flex flex-col overflow-hidden">
+<div
+    x-show="activeTab === 'overlays'"
+    class="flex-1 flex flex-col overflow-hidden"
+>
     <!-- Sub-Tab Switcher -->
     <div class="px-6 pt-3 flex gap-1 border-b border-primary/10">
         <button
             @click="overlaySubTab = 'hunt'"
             :class="overlaySubTab === 'hunt' ? 'border-b-2 border-primary text-text' : 'text-text-muted hover:text-text'"
-            class="text-sm font-medium px-3 pb-2 transition-colors duration-150">
+            class="text-sm font-medium px-3 pb-2 transition-colors duration-150"
+        >
             Hunt Overlays
         </button>
         <button
             @click="overlaySubTab = 'stats'"
             :class="overlaySubTab === 'stats' ? 'border-b-2 border-primary text-text' : 'text-text-muted hover:text-text'"
-            class="text-sm font-medium px-3 pb-2 transition-colors duration-150">
+            class="text-sm font-medium px-3 pb-2 transition-colors duration-150"
+        >
             Stats Overlays
         </button>
     </div>
     <!-- New Overlay Header -->
     <div class="px-6 py-3 border-b border-primary/10 flex items-center gap-2">
         <div x-show="!showNewOverlay">
-            <button @click="showNewOverlay = true" class="flex items-center gap-2 px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150">
+            <button
+                @click="showNewOverlay = true"
+                class="flex items-center gap-2 px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150"
+            >
                 + New Overlay
             </button>
         </div>
@@ -28,81 +36,207 @@
                 @keydown.enter="addOverlay()"
                 @keydown.escape="showNewOverlay = false; newOverlayName = ''"
                 placeholder="Overlay name..."
+                data-testid="overlay-name-input"
                 class="bg-bg-card border border-primary/20 rounded-lg px-3 py-1.5 text-sm text-text placeholder-text-muted/30 focus:outline-none focus:border-primary/60 transition-colors duration-150"
             />
-            <button @click="addOverlay()" class="px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150">Add</button>
-            <button @click="showNewOverlay = false; newOverlayName = ''" class="text-text-muted/50 hover:text-text-muted text-sm transition-colors">Cancel</button>
+            <button
+                @click="addOverlay()"
+                class="px-3 py-1.5 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-text transition-colors duration-150"
+            >
+                Add
+            </button>
+            <button
+                @click="showNewOverlay = false; newOverlayName = ''"
+                class="text-text-muted/50 hover:text-text-muted text-sm transition-colors"
+            >
+                Cancel
+            </button>
         </div>
     </div>
     <!-- Overlay Cards -->
     <div class="flex-1 overflow-y-auto px-6 py-4 space-y-3">
-        <template x-for="overlay in overlays.filter(o => (o.type || 'hunt') === overlaySubTab)" :key="overlay.id">
-            <div :data-overlay-id="overlay.id" class="bg-bg-card rounded-xl overflow-hidden">
+        <template
+            x-for="overlay in overlays.filter(o => (o.type || 'hunt') === overlaySubTab)"
+            :key="overlay.id"
+        >
+            <div
+                :data-overlay-id="overlay.id"
+                class="bg-bg-card rounded-xl overflow-hidden"
+            >
                 <!-- Overlay Header -->
-                <div class="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-primary/5 transition-colors duration-150"
-                    @click="selectedOverlayId = selectedOverlayId === overlay.id ? null : overlay.id">
-                    <span class="flex-1 text-sm font-semibold text-text" x-text="overlay.name"></span>
-                    <button @click.stop="copyOverlayUrl(overlay)" title="Copy overlay URL" class="text-xs text-text-muted hover:text-text transition-colors px-2 py-1 rounded hover:bg-primary/10">Copy URL</button>
-                    <button @click.stop="deleteOverlay(overlay.id)" title="Delete overlay" class="text-text-muted/50 hover:text-danger hover:bg-danger/10 rounded p-1 transition-colors duration-150">
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                <div
+                    class="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-primary/5 transition-colors duration-150"
+                    @click="selectedOverlayId = selectedOverlayId === overlay.id ? null : overlay.id"
+                    data-testid="overlay-header"
+                >
+                    <span
+                        class="flex-1 text-sm font-semibold text-text"
+                        x-text="overlay.name"
+                    ></span>
+                    <button
+                        @click.stop="copyOverlayUrl(overlay)"
+                        title="Copy overlay URL"
+                        class="text-xs text-text-muted hover:text-text transition-colors px-2 py-1 rounded hover:bg-primary/10"
+                    >
+                        Copy URL
+                    </button>
+                    <button
+                        @click.stop="deleteOverlay(overlay.id)"
+                        title="Delete overlay"
+                        class="text-text-muted/50 hover:text-danger hover:bg-danger/10 rounded p-1 transition-colors duration-150"
+                    >
+                        <svg
+                            class="w-3.5 h-3.5"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                            />
                         </svg>
                     </button>
-                    <svg class="w-4 h-4 text-text-muted/50 transition-transform duration-150" :class="selectedOverlayId === overlay.id ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    <svg
+                        class="w-4 h-4 text-text-muted/50 transition-transform duration-150"
+                        :class="selectedOverlayId === overlay.id ? 'rotate-180' : ''"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M19 9l-7 7-7-7"
+                        />
                     </svg>
                 </div>
                 <!-- Hunt Overlay Config -->
-                <div x-show="selectedOverlayId === overlay.id && (overlay.type || 'hunt') === 'hunt'" class="border-t border-primary/10 px-4 py-2 space-y-1">
-                    <template x-if="hunts.filter(h => h.status === 'active' || !h.status).length === 0">
-                        <div class="text-xs text-text-muted/50 py-2">No active hunts</div>
+                <div
+                    x-show="selectedOverlayId === overlay.id && (overlay.type || 'hunt') === 'hunt'"
+                    class="border-t border-primary/10 px-4 py-2 space-y-1"
+                >
+                    <template
+                        x-if="hunts.filter(h => h.status === 'active' || !h.status).length === 0"
+                    >
+                        <div class="text-xs text-text-muted/50 py-2">
+                            No active hunts
+                        </div>
                     </template>
-                    <template x-for="hunt in hunts.filter(h => h.status === 'active' || !h.status)" :key="hunt.id">
-                        <label :data-hunt-id="hunt.id" class="flex items-center gap-3 py-1.5 cursor-pointer group">
+                    <template
+                        x-for="hunt in hunts.filter(h => h.status === 'active' || !h.status)"
+                        :key="hunt.id"
+                    >
+                        <label
+                            :data-overlay-hunt-id="hunt.id"
+                            class="flex items-center gap-3 py-1.5 cursor-pointer group"
+                        >
                             <input
                                 type="checkbox"
                                 :checked="overlay.hunts.find(h => h.huntId === hunt.id)?.visible ?? false"
                                 @change="toggleHuntVisibility(overlay.id, hunt.id)"
                                 class="accent-primary"
                             />
-                            <img x-show="hunt.spriteUrl" :src="hunt.spriteUrl" class="w-6 h-6 object-contain" style="image-rendering: pixelated;" />
-                            <span class="text-sm text-text-muted group-hover:text-text transition-colors" x-text="hunt.displayName"></span>
+                            <img
+                                x-show="hunt.spriteUrl"
+                                :src="hunt.spriteUrl"
+                                class="w-6 h-6 object-contain"
+                                style="image-rendering: pixelated"
+                            />
+                            <span
+                                class="text-sm text-text-muted group-hover:text-text transition-colors"
+                                x-text="hunt.displayName"
+                            ></span>
                         </label>
                     </template>
-                    <div class="border-t border-primary/10 px-4 py-2 flex items-center gap-4">
-                        <span class="text-xs text-text-muted/50 uppercase tracking-wider">Show</span>
-                        <label data-testid="toggle-sprite" class="flex items-center gap-1.5 cursor-pointer">
-                            <input type="checkbox" :checked="overlay.elements.sprite" @change="updateOverlayElement(overlay.id, 'sprite', $event.target.checked)" class="accent-primary" />
+                    <div
+                        class="border-t border-primary/10 px-4 py-2 flex items-center gap-4"
+                    >
+                        <span
+                            class="text-xs text-text-muted/50 uppercase tracking-wider"
+                            >Show</span
+                        >
+                        <label
+                            data-testid="toggle-sprite"
+                            class="flex items-center gap-1.5 cursor-pointer"
+                        >
+                            <input
+                                type="checkbox"
+                                :checked="overlay.elements.sprite"
+                                @change="updateOverlayElement(overlay.id, 'sprite', $event.target.checked)"
+                                class="accent-primary"
+                            />
                             <span class="text-xs text-text-muted">Sprite</span>
                         </label>
-                        <label data-testid="toggle-name" class="flex items-center gap-1.5 cursor-pointer">
-                            <input type="checkbox" :checked="overlay.elements.name" @change="updateOverlayElement(overlay.id, 'name', $event.target.checked)" class="accent-primary" />
+                        <label
+                            data-testid="toggle-name"
+                            class="flex items-center gap-1.5 cursor-pointer"
+                        >
+                            <input
+                                type="checkbox"
+                                :checked="overlay.elements.name"
+                                @change="updateOverlayElement(overlay.id, 'name', $event.target.checked)"
+                                class="accent-primary"
+                            />
                             <span class="text-xs text-text-muted">Name</span>
                         </label>
-                        <label data-testid="toggle-count" class="flex items-center gap-1.5 cursor-pointer">
-                            <input type="checkbox" :checked="overlay.elements.count" @change="updateOverlayElement(overlay.id, 'count', $event.target.checked)" class="accent-primary" />
+                        <label
+                            data-testid="toggle-count"
+                            class="flex items-center gap-1.5 cursor-pointer"
+                        >
+                            <input
+                                type="checkbox"
+                                :checked="overlay.elements.count"
+                                @change="updateOverlayElement(overlay.id, 'count', $event.target.checked)"
+                                class="accent-primary"
+                            />
                             <span class="text-xs text-text-muted">Count</span>
                         </label>
-                        <label data-testid="toggle-odds" class="flex items-center gap-1.5 cursor-pointer">
-                            <input type="checkbox" :checked="overlay.elements.odds" @change="updateOverlayElement(overlay.id, 'odds', $event.target.checked)" class="accent-primary" />
+                        <label
+                            data-testid="toggle-odds"
+                            class="flex items-center gap-1.5 cursor-pointer"
+                        >
+                            <input
+                                type="checkbox"
+                                :checked="overlay.elements.odds"
+                                @change="updateOverlayElement(overlay.id, 'odds', $event.target.checked)"
+                                class="accent-primary"
+                            />
                             <span class="text-xs text-text-muted">Odds</span>
                         </label>
                     </div>
                 </div>
                 <!-- Stats Overlay Config -->
-                <div x-show="selectedOverlayId === overlay.id && overlay.type === 'stats'" class="border-t border-primary/10 px-4 py-3 space-y-3">
+                <div
+                    x-show="selectedOverlayId === overlay.id && overlay.type === 'stats'"
+                    class="border-t border-primary/10 px-4 py-3 space-y-3"
+                >
                     <!-- Total Completed Toggle -->
                     <label class="flex items-center gap-3 cursor-pointer">
-                        <input type="checkbox" :checked="overlay.elements.totalCompleted" @change="updateOverlayElement(overlay.id, 'totalCompleted', $event.target.checked)" class="accent-primary" />
-                        <span class="text-sm text-text-muted">Show total completed hunts</span>
+                        <input
+                            type="checkbox"
+                            :checked="overlay.elements.totalCompleted"
+                            @change="updateOverlayElement(overlay.id, 'totalCompleted', $event.target.checked)"
+                            class="accent-primary"
+                        />
+                        <span class="text-sm text-text-muted"
+                            >Show total completed hunts</span
+                        >
                     </label>
                     <!-- Breakdown -->
                     <div class="flex items-center gap-3">
-                        <span class="text-xs text-text-muted/50 uppercase tracking-wider">Breakdown</span>
+                        <span
+                            class="text-xs text-text-muted/50 uppercase tracking-wider"
+                            >Breakdown</span
+                        >
                         <select
                             :value="overlay.elements.breakdown"
                             @change="updateOverlayElement(overlay.id, 'breakdown', $event.target.value || null)"
-                            class="bg-bg-surface border border-primary/20 rounded-lg px-2 py-1 text-sm text-text-muted focus:outline-none focus:border-primary/60">
+                            class="bg-bg-surface border border-primary/20 rounded-lg px-2 py-1 text-sm text-text-muted focus:outline-none focus:border-primary/60"
+                        >
                             <option value="">None</option>
                             <option value="completed">Completed hunts</option>
                             <option value="active">Active hunts</option>
@@ -110,11 +244,15 @@
                     </div>
                     <!-- Game Filter -->
                     <div class="flex items-center gap-3">
-                        <span class="text-xs text-text-muted/50 uppercase tracking-wider">Game</span>
+                        <span
+                            class="text-xs text-text-muted/50 uppercase tracking-wider"
+                            >Game</span
+                        >
                         <select
                             :value="overlay.game || ''"
                             @change="updateOverlayGame(overlay.id, $event.target.value)"
-                            class="bg-bg-surface border border-primary/20 rounded-lg px-2 py-1 text-sm text-text-muted focus:outline-none focus:border-primary/60">
+                            class="bg-bg-surface border border-primary/20 rounded-lg px-2 py-1 text-sm text-text-muted focus:outline-none focus:border-primary/60"
+                        >
                             <option value="">All Games</option>
                             <template x-for="game in games" :key="game">
                                 <option :value="game" x-text="game"></option>

--- a/templates/partials/_overlays_tab.html
+++ b/templates/partials/_overlays_tab.html
@@ -37,7 +37,7 @@
     <!-- Overlay Cards -->
     <div class="flex-1 overflow-y-auto px-6 py-4 space-y-3">
         <template x-for="overlay in overlays.filter(o => (o.type || 'hunt') === overlaySubTab)" :key="overlay.id">
-            <div class="bg-bg-card rounded-xl overflow-hidden">
+            <div :data-overlay-id="overlay.id" class="bg-bg-card rounded-xl overflow-hidden">
                 <!-- Overlay Header -->
                 <div class="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-primary/5 transition-colors duration-150"
                     @click="selectedOverlayId = selectedOverlayId === overlay.id ? null : overlay.id">
@@ -58,7 +58,7 @@
                         <div class="text-xs text-text-muted/50 py-2">No active hunts</div>
                     </template>
                     <template x-for="hunt in hunts.filter(h => h.status === 'active' || !h.status)" :key="hunt.id">
-                        <label class="flex items-center gap-3 py-1.5 cursor-pointer group">
+                        <label :data-hunt-id="hunt.id" class="flex items-center gap-3 py-1.5 cursor-pointer group">
                             <input
                                 type="checkbox"
                                 :checked="overlay.hunts.find(h => h.huntId === hunt.id)?.visible ?? false"
@@ -71,19 +71,19 @@
                     </template>
                     <div class="border-t border-primary/10 px-4 py-2 flex items-center gap-4">
                         <span class="text-xs text-text-muted/50 uppercase tracking-wider">Show</span>
-                        <label class="flex items-center gap-1.5 cursor-pointer">
+                        <label data-testid="toggle-sprite" class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.sprite" @change="updateOverlayElement(overlay.id, 'sprite', $event.target.checked)" class="accent-primary" />
                             <span class="text-xs text-text-muted">Sprite</span>
                         </label>
-                        <label class="flex items-center gap-1.5 cursor-pointer">
+                        <label data-testid="toggle-name" class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.name" @change="updateOverlayElement(overlay.id, 'name', $event.target.checked)" class="accent-primary" />
                             <span class="text-xs text-text-muted">Name</span>
                         </label>
-                        <label class="flex items-center gap-1.5 cursor-pointer">
+                        <label data-testid="toggle-count" class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.count" @change="updateOverlayElement(overlay.id, 'count', $event.target.checked)" class="accent-primary" />
                             <span class="text-xs text-text-muted">Count</span>
                         </label>
-                        <label class="flex items-center gap-1.5 cursor-pointer">
+                        <label data-testid="toggle-odds" class="flex items-center gap-1.5 cursor-pointer">
                             <input type="checkbox" :checked="overlay.elements.odds" @change="updateOverlayElement(overlay.id, 'odds', $event.target.checked)" class="accent-primary" />
                             <span class="text-xs text-text-muted">Odds</span>
                         </label>

--- a/templates/partials/_stats_tab.html
+++ b/templates/partials/_stats_tab.html
@@ -4,11 +4,11 @@
         <div class="text-xs font-semibold uppercase tracking-widest text-text-muted/50 mb-4">Overall</div>
         <div class="grid grid-cols-2 gap-4">
             <div class="bg-bg-surface rounded-lg p-4 text-center">
-                <div class="text-3xl font-bold text-gold" x-text="hunts.filter(h => h.status === 'completed').length"></div>
+                <div data-testid="completed-count" class="text-3xl font-bold text-gold" x-text="hunts.filter(h => h.status === 'completed').length"></div>
                 <div class="text-xs text-text-muted mt-1">Completed</div>
             </div>
             <div class="bg-bg-surface rounded-lg p-4 text-center">
-                <div class="text-3xl font-bold text-primary-light" x-text="hunts.filter(h => h.status === 'active' || !h.status).length"></div>
+                <div data-testid="active-count" class="text-3xl font-bold text-primary-light" x-text="hunts.filter(h => h.status === 'active' || !h.status).length"></div>
                 <div class="text-xs text-text-muted mt-1">Active</div>
             </div>
         </div>

--- a/tests/e2e/test_counter.py
+++ b/tests/e2e/test_counter.py
@@ -26,7 +26,7 @@ def test_reset_count(page: Page, base_url: str):
     page.request.post(f"{base_url}/api/hunts/{hunt['id']}/increment")
 
     page.goto(base_url)
-    page.locator("button[title='Reset count']").first.click()
+    page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Reset count']").click()
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])
@@ -39,7 +39,9 @@ def test_manual_count_entry(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
 
     page.goto(base_url)
-    count_input = page.locator("input.text-gold").first
+    count_input = page.locator(
+        f"[data-hunt-id='{hunt['id']}'] [data-testid='count-input']"
+    )
     count_input.fill("42")
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "PUT"
@@ -57,7 +59,7 @@ def test_count_cannot_go_below_zero(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
 
     page.goto(base_url)
-    page.get_by_role("button", name="-", exact=True).first.click()
+    page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Decrement']").click()
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])
@@ -77,7 +79,9 @@ def test_count_persistence(page: Page, base_url: str):
 
     page.goto(base_url)
     page.reload()
-    expect(page.locator("input.text-gold").first).to_have_value("77")
+    expect(
+        page.locator(f"[data-hunt-id='{hunt['id']}'] [data-testid='count-input']")
+    ).to_have_value("77")
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])

--- a/tests/e2e/test_export.py
+++ b/tests/e2e/test_export.py
@@ -116,8 +116,8 @@ def test_export_modal_opens(page: Page, base_url: str):
     page.goto(base_url)
     page.get_by_role("button", name="Export").click()
     expect(page.get_by_text("Export Hunts")).to_be_visible()
-    expect(page.locator("input[name='export_scope']").first).to_be_visible()
-    expect(page.locator("input[name='export_format']").first).to_be_visible()
+    expect(page.locator("input[name='export_scope'][value='all']")).to_be_visible()
+    expect(page.locator("input[name='export_format'][value='json']")).to_be_visible()
 
 
 def test_export_toast_appears(page: Page, base_url: str):

--- a/tests/e2e/test_history.py
+++ b/tests/e2e/test_history.py
@@ -23,7 +23,7 @@ def test_mark_found_notes_appear_in_history(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
     page.goto(base_url)
 
-    page.locator("button[title='Mark as Found']").first.click()
+    page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Mark as Found']").click()
     expect(
         page.get_by_placeholder("How did you find it? Any thoughts...")
     ).to_be_visible()
@@ -60,9 +60,9 @@ def test_mark_found_shows_count_in_history(page: Page, base_url: str):
     page.goto(base_url)
     page.get_by_text("History", exact=True).click()
     expect(
-        page.locator(".bg-bg-card")
-        .filter(has_text="Meowth")
-        .locator(".text-gold", has_text="150")
+        page.locator(
+            f"[data-hunt-id='{hunt['id']}'] [data-testid='final-count']", has_text="150"
+        )
     ).to_be_visible()
 
     resp = page.request.get(f"{base_url}/api/hunts?scope=all")
@@ -85,7 +85,9 @@ def test_mark_found_immediate_when_behavior_is_never(page: Page, base_url: str):
         lambda r: f"/api/hunts/{hunt['id']}/complete" in r.url
         and r.request.method == "POST"
     ):
-        page.locator("button[title='Mark as Found']").first.click()
+        page.locator(
+            f"[data-hunt-id='{hunt['id']}'] button[title='Mark as Found']"
+        ).click()
 
     expect(
         page.get_by_placeholder("How did you find it? Any thoughts...")
@@ -118,9 +120,7 @@ def test_delete_from_history(page: Page, base_url: str):
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "DELETE"
     ):
-        page.locator(".bg-bg-card").filter(has_text="Meowth").locator(
-            "button[title='Delete']"
-        ).click()
+        page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Delete']").click()
 
     resp = page.request.get(f"{base_url}/api/hunts?scope=all")
     assert not any(h["id"] == hunt["id"] for h in resp.json())

--- a/tests/e2e/test_history.py
+++ b/tests/e2e/test_history.py
@@ -35,10 +35,10 @@ def test_mark_found_notes_appear_in_history(page: Page, base_url: str):
         lambda r: f"/api/hunts/{hunt['id']}/complete" in r.url
         and r.request.method == "POST"
     ):
-        page.get_by_role("button", name="Mark as Found").last.click()
+        page.locator("[data-testid='confirm-mark-found']").click()
 
     page.get_by_text("History", exact=True).click()
-    expect(page.get_by_text("Meowth", exact=True).first).to_be_visible()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible()
     expect(page.get_by_text("Got it on encounter 42!")).to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
@@ -115,7 +115,7 @@ def test_delete_from_history(page: Page, base_url: str):
 
     page.goto(base_url)
     page.get_by_text("History", exact=True).click()
-    expect(page.get_by_text("Meowth", exact=True).first).to_be_visible()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible()
 
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "DELETE"
@@ -138,7 +138,7 @@ def test_completed_hunt_persists_in_history(page: Page, base_url: str):
     page.reload()
 
     page.get_by_text("History", exact=True).click()
-    expect(page.get_by_text("Meowth", exact=True).first).to_be_visible()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible()
     expect(page.get_by_text("Persistence test")).to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")

--- a/tests/e2e/test_hotkeys.py
+++ b/tests/e2e/test_hotkeys.py
@@ -23,8 +23,8 @@ def test_set_increment_hotkey(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
     page.goto(base_url)
 
-    card = page.locator(".bg-bg-card").filter(has_text="Zubat")
-    card.locator("button", has_text="Set").first.click()
+    card = page.locator(f"[data-hunt-id='{hunt['id']}']")
+    card.locator("button[title='Edit increment hotkey']").click()
     expect(page.get_by_text("Press a key...")).to_be_visible()
 
     with page.expect_response(
@@ -43,8 +43,8 @@ def test_set_decrement_hotkey(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
     page.goto(base_url)
 
-    card = page.locator(".bg-bg-card").filter(has_text="Zubat")
-    card.locator("button", has_text="Set").nth(1).click()
+    card = page.locator(f"[data-hunt-id='{hunt['id']}']")
+    card.locator("button[title='Edit decrement hotkey']").click()
     expect(page.get_by_text("Press a key...")).to_be_visible()
 
     with page.expect_response(
@@ -71,7 +71,9 @@ def test_clear_increment_hotkey(page: Page, base_url: str):
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "PUT"
     ):
-        page.locator("button[title='Clear increment hotkey']").first.click()
+        page.locator(
+            f"[data-hunt-id='{hunt['id']}'] button[title='Clear increment hotkey']"
+        ).click()
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])
@@ -92,7 +94,9 @@ def test_clear_decrement_hotkey(page: Page, base_url: str):
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "PUT"
     ):
-        page.locator("button[title='Clear decrement hotkey']").first.click()
+        page.locator(
+            f"[data-hunt-id='{hunt['id']}'] button[title='Clear decrement hotkey']"
+        ).click()
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])
@@ -105,8 +109,8 @@ def test_cancel_hotkey_capture(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
     page.goto(base_url)
 
-    card = page.locator(".bg-bg-card").filter(has_text="Zubat")
-    card.locator("button", has_text="Set").first.click()
+    card = page.locator(f"[data-hunt-id='{hunt['id']}']")
+    card.locator("button[title='Edit increment hotkey']").click()
     expect(page.get_by_text("Press a key...")).to_be_visible()
 
     page.locator("button[title='Cancel capture']").click()
@@ -130,9 +134,13 @@ def test_hotkey_persistence(page: Page, base_url: str):
     page.goto(base_url)
     page.reload()
 
-    card = page.locator(".bg-bg-card").filter(has_text="Zubat")
-    expect(card.locator("span.font-mono", has_text="Ctrl+F7")).to_be_visible()
-    expect(card.locator("span.font-mono", has_text="Shift+F7")).to_be_visible()
+    card = page.locator(f"[data-hunt-id='{hunt['id']}']")
+    expect(
+        card.locator("[data-testid='badge-hotkey']", has_text="Ctrl+F7")
+    ).to_be_visible()
+    expect(
+        card.locator("[data-testid='badge-hotkey-decrement']", has_text="Shift+F7")
+    ).to_be_visible()
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])

--- a/tests/e2e/test_hunt_management.py
+++ b/tests/e2e/test_hunt_management.py
@@ -27,7 +27,9 @@ def test_delete_hunt(page: Page, base_url: str):
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "DELETE"
     ):
-        page.locator("button[title='Delete Hunt']").first.click()
+        page.locator(
+            f"[data-hunt-id='{hunt['id']}'] button[title='Delete Hunt']"
+        ).click()
 
     resp = page.request.get(f"{base_url}/api/hunts")
     assert not any(h["id"] == hunt["id"] for h in resp.json())
@@ -40,7 +42,9 @@ def test_set_encounter_rate(page: Page, base_url: str):
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "PUT"
     ):
-        odds_input = page.get_by_placeholder("Odds").first
+        odds_input = page.locator(
+            f"[data-hunt-id='{hunt['id']}'] input[placeholder='Odds']"
+        )
         odds_input.fill("4096")
         odds_input.dispatch_event("change")
 
@@ -58,9 +62,9 @@ def test_change_game(page: Page, base_url: str):
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "PUT"
     ):
-        page.locator(".bg-bg-card").filter(has_text="Geodude").locator(
-            "select"
-        ).first.select_option(label="Scarlet / Violet")
+        page.locator(f"[data-hunt-id='{hunt['id']}'] select").select_option(
+            label="Scarlet / Violet"
+        )
 
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])

--- a/tests/e2e/test_hunt_management.py
+++ b/tests/e2e/test_hunt_management.py
@@ -19,10 +19,19 @@ def _create_hunt(page, base_url, pokemon="geodude", display="Geodude"):
     return r.json()
 
 
+def _create_overlay(page, base_url, name, type_="hunt"):
+    r = page.request.post(
+        f"{base_url}/api/overlays",
+        data=json.dumps({"name": name, "type": type_}),
+        headers={"Content-Type": "application/json"},
+    )
+    return r.json()
+
+
 def test_delete_hunt(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
     page.goto(base_url)
-    expect(page.get_by_text("Geodude", exact=True).first).to_be_visible()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible()
 
     with page.expect_response(
         lambda r: f"/api/hunts/{hunt['id']}" in r.url and r.request.method == "DELETE"
@@ -76,13 +85,105 @@ def test_change_game(page: Page, base_url: str):
 def test_add_hunt_with_game(page: Page, base_url: str):
     page.goto(base_url)
     page.get_by_placeholder("Search Pokemon...").fill("snorlax")
-    page.locator("select").first.select_option(label="Scarlet / Violet")
-    page.get_by_role("button", name="Add Hunt").click()
-    expect(page.get_by_text("Snorlax", exact=True).first).to_be_visible(timeout=15000)
+    page.locator("[data-testid='add-hunt-game-select']").select_option(
+        label="Scarlet / Violet"
+    )
 
-    resp = page.request.get(f"{base_url}/api/hunts")
-    snorlax = next((h for h in resp.json() if h["pokemon"] == "snorlax"), None)
-    assert snorlax is not None
+    with page.expect_response(
+        lambda r: "/api/hunts" in r.url and r.request.method == "POST"
+    ) as response_info:
+        page.get_by_role("button", name="Add Hunt").click()
+
+    snorlax = response_info.value.json()
+    expect(page.locator(f"[data-hunt-id='{snorlax['id']}']")).to_be_visible(
+        timeout=15000
+    )
+
     assert snorlax["game"] == "Scarlet / Violet"
 
     page.request.delete(f"{base_url}/api/hunts/{snorlax['id']}")
+
+
+def test_add_hunt_assigns_to_selected_overlay(page: Page, base_url: str):
+    overlay = _create_overlay(page, base_url, name="picker_test")
+    page.goto(base_url)
+
+    page.get_by_placeholder("Search Pokemon...").fill("rattata")
+    page.locator("[data-testid='overlay-picker-trigger']").click()
+    page.locator(
+        f"[data-testid='overlay-picker-popover'] [data-overlay-id='{overlay['id']}'] input[type='checkbox']"
+    ).check()
+
+    with page.expect_response(
+        lambda r: "/api/hunts" in r.url and r.request.method == "POST"
+    ) as response_info:
+        page.get_by_role("button", name="Add Hunt").click()
+
+    hunt = response_info.value.json()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible(timeout=15000)
+
+    all_overlays = page.request.get(f"{base_url}/api/overlays").json()
+    updated = next(o for o in all_overlays if o["id"] == overlay["id"])
+    assert any(h["huntId"] == hunt["id"] for h in updated["hunts"])
+
+    page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
+
+
+def test_add_hunt_select_all_overlays(page: Page, base_url: str):
+    overlay1 = _create_overlay(page, base_url, name="select-all-1")
+    overlay2 = _create_overlay(page, base_url, name="select-all-2")
+    page.goto(base_url)
+
+    page.get_by_placeholder("Search Pokemon...").fill("sentret")
+    page.locator("[data-testid='overlay-picker-trigger']").click()
+    page.locator("[data-testid='select-all-overlays']").check()
+
+    with page.expect_response(
+        lambda r: "/api/hunts" in r.url and r.request.method == "POST"
+    ) as response_info:
+        page.get_by_role("button", name="Add Hunt").click()
+
+    hunt = response_info.value.json()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible(timeout=15000)
+
+    all_overlays = page.request.get(f"{base_url}/api/overlays").json()
+    for overlay in [overlay1, overlay2]:
+        updated = next(o for o in all_overlays if o["id"] == overlay["id"])
+        assert any(h["huntId"] == hunt["id"] for h in updated["hunts"])
+
+    page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay1['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay2['id']}")
+
+
+def test_add_hunt_creates_overlay_from_form(page: Page, base_url: str):
+    page.goto(base_url)
+
+    page.get_by_placeholder("Search Pokemon...").fill("hoothoot")
+    page.locator("[data-testid='overlay-picker-trigger']").click()
+    page.locator("[data-testid='show-new-overlay-form']").click()
+
+    with page.expect_response(
+        lambda r: "/api/overlays" in r.url and r.request.method == "POST"
+    ):
+        page.locator("[data-testid='new-overlay-name-input']").fill("from-form-overlay")
+        page.locator("[data-testid='add-overlay-from-form']").click()
+
+    with page.expect_response(
+        lambda r: "api/hunts" in r.url and r.request.method == "POST"
+    ) as response_info:
+        page.get_by_role("button", name="Add Hunt").click()
+
+    hunt = response_info.value.json()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible(timeout=15000)
+
+    overlays_resp = page.request.get(f"{base_url}/api/overlays")
+    overlay = next(
+        (o for o in overlays_resp.json() if o["name"] == "from-form-overlay"), None
+    )
+    assert overlay is not None
+    assert any(h["huntId"] == hunt["id"] for h in overlay["hunts"])
+
+    page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")

--- a/tests/e2e/test_overlay_rendering.py
+++ b/tests/e2e/test_overlay_rendering.py
@@ -3,15 +3,15 @@ import json
 from playwright.sync_api import Page, expect
 
 
-def _create_hunt(page, base_url, encounter_rate=None):
+def _create_hunt(page, base_url, encounter_rate=None, game=None, name="ditto"):
     r = page.request.post(
         f"{base_url}/api/hunts",
         data=json.dumps(
             {
-                "pokemon": "ditto",
-                "displayName": "Ditto",
+                "pokemon": name,
+                "displayName": name.title(),
                 "spriteUrl": None,
-                "game": None,
+                "game": game,
             }
         ),
         headers={"Content-Type": "application/json"},
@@ -26,13 +26,27 @@ def _create_hunt(page, base_url, encounter_rate=None):
     return hunt
 
 
-def _get_overlay(page, base_url):
-    return page.request.get(f"{base_url}/api/overlays").json()[0]
+def _create_overlay(page: Page, base_url: str):
+    r = page.request.post(
+        f"{base_url}/api/overlays",
+        data=json.dumps({"name": "test-hunt-ov"}),
+        headers={"Content-Type": "application/json"},
+    )
+    return r.json()
+
+
+def _create_stats_overlay(page: Page, base_url: str, name: str):
+    r = page.request.post(
+        f"{base_url}/api/overlays",
+        data=json.dumps({"name": name, "type": "stats"}),
+        headers={"Content-Type": "application/json"},
+    )
+    return r.json()
 
 
 def test_overlay_shows_hunt_name(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
@@ -40,10 +54,11 @@ def test_overlay_shows_hunt_name(page: Page, base_url: str):
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-name", has_text="Ditto")).to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_shows_count(page: Page, base_url: str):
@@ -53,7 +68,7 @@ def test_overlay_shows_count(page: Page, base_url: str):
         data=json.dumps({"count": 99}),
         headers={"Content-Type": "application/json"},
     )
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
@@ -61,15 +76,16 @@ def test_overlay_shows_count(page: Page, base_url: str):
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-count", has_text="99")).to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_count_updates_live(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
@@ -77,18 +93,19 @@ def test_overlay_count_updates_live(page: Page, base_url: str):
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-count", has_text="0")).to_be_visible()
 
     page.request.post(f"{base_url}/api/hunts/{hunt['id']}/increment")
-    expect(page.locator(".hunt-card", has_text="1")).to_be_visible(timeout=5000)
+    expect(page.locator(".hunt-count", has_text="1")).to_be_visible(timeout=5000)
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_hides_hunt_when_visibility_off(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
@@ -96,15 +113,16 @@ def test_overlay_hides_hunt_when_visibility_off(page: Page, base_url: str):
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-name", has_text="Ditto")).not_to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_hides_completed_hunt(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
@@ -112,7 +130,7 @@ def test_overlay_hides_completed_hunt(page: Page, base_url: str):
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-name", has_text="Ditto")).to_be_visible()
 
     page.request.post(
@@ -123,139 +141,106 @@ def test_overlay_hides_completed_hunt(page: Page, base_url: str):
     expect(page.locator(".hunt-name", has_text="Ditto")).not_to_be_visible(timeout=5000)
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_shows_odds_when_enabled(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url, encounter_rate=4096)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
         data=json.dumps({"hunts": [{"huntId": hunt["id"], "visible": True}]}),
         headers={"Content-Type": "application/json"},
     )
-
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
         data=json.dumps({"elements": {**overlay["elements"], "odds": True}}),
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-odds", has_text="1/4,096")).to_be_visible()
 
-    # Restore
-    page.request.put(
-        f"{base_url}/api/overlays/{overlay['id']}",
-        data=json.dumps({"elements": {**overlay["elements"], "odds": False}}),
-        headers={"Content-Type": "application/json"},
-    )
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_hides_name_when_disabled(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
         data=json.dumps({"hunts": [{"huntId": hunt["id"], "visible": True}]}),
         headers={"Content-Type": "application/json"},
     )
-
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
         data=json.dumps({"elements": {**overlay["elements"], "name": False}}),
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-name")).not_to_be_visible()
 
-    # Restore
-    page.request.put(
-        f"{base_url}/api/overlays/{overlay['id']}",
-        data=json.dumps({"elements": {**overlay["elements"], "name": True}}),
-        headers={"Content-Type": "application/json"},
-    )
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_hides_count_when_disabled(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlay = _get_overlay(page, base_url)
+    overlay = _create_overlay(page, base_url)
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
         data=json.dumps({"hunts": [{"huntId": hunt["id"], "visible": True}]}),
         headers={"Content-Type": "application/json"},
     )
-
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
         data=json.dumps({"elements": {**overlay["elements"], "count": False}}),
         headers={"Content-Type": "application/json"},
     )
 
-    page.goto(f"{base_url}/overlay/{overlay['name']}")
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator(".hunt-count")).not_to_be_visible()
 
-    # Restore
-    page.request.put(
-        f"{base_url}/api/overlays/{overlay['id']}",
-        data=json.dumps({"elements": {**overlay["elements"], "count": True}}),
-        headers={"Content-Type": "application/json"},
-    )
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
-
-
-def test_overlay_redirect(page: Page, base_url: str):
-    page.goto(f"{base_url}/overlay")
-    expect(page).to_have_url(f"{base_url}/overlay/main")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_not_found(page: Page, base_url: str):
-    resp = page.request.get(f"{base_url}/overlay/doesnotexist")
+    resp = page.request.get(f"{base_url}/overlay/doesntexist")
+    assert resp.status == 404
+
+
+def test_overlay_bare_path_not_found(page: Page, base_url: str):
+    resp = page.request.get(f"{base_url}/overlay")
     assert resp.status == 404
 
 
 def test_stats_overlay_shows_total_completed(page: Page, base_url: str):
-    hunt = page.request.post(
-        f"{base_url}/api/hunts",
-        data=json.dumps(
-            {
-                "pokemon": "eevee",
-                "displayName": "Eevee",
-                "spriteUrl": None,
-                "game": None,
-            }
-        ),
-        headers={"Content-Type": "application/json"},
-    ).json()
+    hunt = _create_hunt(page, base_url)
+
     page.request.post(
         f"{base_url}/api/hunts/{hunt['id']}/complete",
         data=json.dumps({}),
         headers={"Content-Type": "application/json"},
     )
-    stats_ov = page.request.post(
-        f"{base_url}/api/overlays",
-        data=json.dumps({"name": "test-stats-total", "type": "stats"}),
-        headers={"Content-Type": "application/json"},
-    ).json()
+    stats_ov = _create_stats_overlay(page, base_url, name="test-stats-total")
 
     page.goto(f"{base_url}/overlay/{stats_ov['name']}-stats")
-    expect(page.locator(".stat-line", has_text="Total Completed")).to_be_visible()
+    expect(
+        page.locator(".stat-line", has_text="Total Completed: 1 hunt")
+    ).to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
     page.request.delete(f"{base_url}/api/overlays/{stats_ov['id']}")
 
 
 def test_stats_overlay_breakdown_completed(page: Page, base_url: str):
-    stats_ov = page.request.post(
-        f"{base_url}/api/overlays",
-        data=json.dumps({"name": "test-stats-breakdown", "type": "stats"}),
-        headers={"Content-Type": "application/json"},
-    ).json()
+    stats_ov = _create_stats_overlay(page, base_url, name="test-stats-breakdown")
     page.request.put(
         f"{base_url}/api/overlays/{stats_ov['id']}",
         data=json.dumps(
@@ -271,11 +256,7 @@ def test_stats_overlay_breakdown_completed(page: Page, base_url: str):
 
 
 def test_stats_overlay_breakdown_active(page: Page, base_url: str):
-    stats_ov = page.request.post(
-        f"{base_url}/api/overlays",
-        data=json.dumps({"name": "test-stats-active", "type": "stats"}),
-        headers={"Content-Type": "application/json"},
-    ).json()
+    stats_ov = _create_stats_overlay(page, base_url, name="test-stats-active")
     page.request.put(
         f"{base_url}/api/overlays/{stats_ov['id']}",
         data=json.dumps({"elements": {"totalCompleted": True, "breakdown": "active"}}),
@@ -289,40 +270,16 @@ def test_stats_overlay_breakdown_active(page: Page, base_url: str):
 
 
 def test_stats_overlay_game_filter(page: Page, base_url: str):
-    hunt1 = page.request.post(
-        f"{base_url}/api/hunts",
-        data=json.dumps(
-            {
-                "pokemon": "pikachu",
-                "displayName": "Pikachu",
-                "spriteUrl": None,
-                "game": "Yellow",
-            }
-        ),
-        headers={"Content-Type": "application/json"},
-    ).json()
-    hunt2 = page.request.post(
-        f"{base_url}/api/hunts",
-        data=json.dumps(
-            {
-                "pokemon": "mewtwo",
-                "displayName": "Mewtwo",
-                "spriteUrl": None,
-                "game": "Red / Blue",
-            }
-        ),
-        headers={"Content-Type": "application/json"},
-    ).json()
+    hunt1 = _create_hunt(page, base_url, game="Yellow")
+    hunt2 = _create_hunt(page, base_url, game="Red / Blue", name="pikachu")
+
     page.request.post(
         f"{base_url}/api/hunts/{hunt1['id']}/complete",
         data=json.dumps({}),
         headers={"Content-Type": "application/json"},
     )
-    stats_ov = page.request.post(
-        f"{base_url}/api/overlays",
-        data=json.dumps({"name": "test-stats-game", "type": "stats"}),
-        headers={"Content-Type": "application/json"},
-    ).json()
+
+    stats_ov = _create_stats_overlay(page, base_url, name="test-stats-game")
     page.request.put(
         f"{base_url}/api/overlays/{stats_ov['id']}",
         data=json.dumps(

--- a/tests/e2e/test_overlays.py
+++ b/tests/e2e/test_overlays.py
@@ -32,18 +32,16 @@ def test_create_overlay(page: Page, base_url: str):
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
     page.get_by_role("button", name="+ New Overlay").click()
-    page.get_by_placeholder("Overlay name...").fill("overlay2")
+    page.locator("[data-testid='overlay-name-input']").fill("overlay2")
 
     with page.expect_response(
         lambda r: "/api/overlays" in r.url and r.request.method == "POST"
-    ):
+    ) as response_info:
         page.get_by_role("button", name="Add").click()
 
-    expect(page.get_by_text("overlay2")).to_be_visible()
-
-    resp = page.request.get(f"{base_url}/api/overlays")
-    overlay = next((o for o in resp.json() if o["name"] == "overlay2"), None)
-    assert overlay is not None
+    overlay = response_info.value.json()
+    expect(page.locator(f"div[data-overlay-id='{overlay['id']}']")).to_be_visible()
+    assert overlay["name"] == "overlay2"
 
     page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
@@ -53,7 +51,7 @@ def test_delete_overlay(page: Page, base_url: str):
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    expect(page.get_by_text("temp-overlay")).to_be_visible()
+    expect(page.locator(f"div[data-overlay-id='{overlay['id']}']")).to_be_visible()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
@@ -91,14 +89,16 @@ def test_toggle_hunt_visibility(page: Page, base_url: str):
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.locator(f"[data-overlay-id='{overlay['id']}'] div.cursor-pointer").click()
+    page.locator(
+        f"[data-overlay-id='{overlay['id']}'] [data-testid='overlay-header']"
+    ).click()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
         and r.request.method == "PUT"
     ):
         page.locator(
-            f"label[data-hunt-id='{hunt['id']}'] input[type='checkbox']"
+            f"[data-overlay-id='{overlay['id']}'] label[data-overlay-hunt-id='{hunt['id']}'] input[type='checkbox']"
         ).click()
 
     resp = page.request.get(f"{base_url}/api/overlays")
@@ -115,7 +115,9 @@ def test_overlay_element_toggle_odds(page: Page, base_url: str):
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.locator(f"[data-overlay-id='{overlay['id']}'] div.cursor-pointer").click()
+    page.locator(
+        f"[data-overlay-id='{overlay['id']}'] [data-testid='overlay-header']"
+    ).click()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
@@ -137,7 +139,9 @@ def test_overlay_element_toggle_sprite(page: Page, base_url: str):
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.locator(f"[data-overlay-id='{overlay['id']}'] div.cursor-pointer").click()
+    page.locator(
+        f"[data-overlay-id='{overlay['id']}'] [data-testid='overlay-header']"
+    ).click()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
@@ -160,7 +164,7 @@ def test_overlay_persistence(page: Page, base_url: str):
     page.goto(base_url)
     page.reload()
     page.get_by_text("Overlays", exact=True).click()
-    expect(page.get_by_text("persist-overlay")).to_be_visible()
+    expect(page.locator(f"div[data-overlay-id='{overlay['id']}']")).to_be_visible()
 
     resp = page.request.get(f"{base_url}/api/overlays")
     assert any(o["name"] == "persist-overlay" for o in resp.json())
@@ -205,7 +209,7 @@ def test_create_stats_overlay(page: Page, base_url: str):
     page.get_by_text("Overlays", exact=True).click()
     page.get_by_text("Stats Overlays").click()
     page.get_by_role("button", name="+ New Overlay").click()
-    page.get_by_placeholder("Overlay name...").fill("my-stats")
+    page.locator("[data-testid='overlay-name-input']").fill("my-stats")
 
     with page.expect_response(
         lambda r: "/api/overlays" in r.url and r.request.method == "POST"

--- a/tests/e2e/test_overlays.py
+++ b/tests/e2e/test_overlays.py
@@ -59,8 +59,8 @@ def test_delete_overlay(page: Page, base_url: str):
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
         and r.request.method == "DELETE"
     ):
-        page.locator(".bg-bg-card").filter(has_text="temp-overlay").locator(
-            "button[title='Delete overlay']"
+        page.locator(
+            f"[data-overlay-id='{overlay['id']}'] button[title='Delete overlay']"
         ).click()
 
     resp = page.request.get(f"{base_url}/api/overlays")
@@ -68,15 +68,20 @@ def test_delete_overlay(page: Page, base_url: str):
 
 
 def test_delete_overlay_enabled_when_only_one(page: Page, base_url: str):
+    overlay = _create_overlay(page, base_url, name="test-one-overlay")
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    expect(page.locator("button[title='Delete overlay']")).to_be_enabled()
+    expect(
+        page.locator(
+            f"[data-overlay-id='{overlay['id']}'] button[title='Delete overlay']"
+        )
+    ).to_be_enabled()
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_toggle_hunt_visibility(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
-    overlays = page.request.get(f"{base_url}/api/overlays").json()
-    overlay = overlays[0]
+    overlay = _create_overlay(page, base_url, name="test-visibility")
 
     page.request.put(
         f"{base_url}/api/overlays/{overlay['id']}",
@@ -86,14 +91,14 @@ def test_toggle_hunt_visibility(page: Page, base_url: str):
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.get_by_text(overlay["name"]).first.click()
+    page.locator(f"[data-overlay-id='{overlay['id']}'] div.cursor-pointer").click()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
         and r.request.method == "PUT"
     ):
-        page.locator("label").filter(has_text="Magikarp").locator(
-            "input[type='checkbox']"
+        page.locator(
+            f"label[data-hunt-id='{hunt['id']}'] input[type='checkbox']"
         ).click()
 
     resp = page.request.get(f"{base_url}/api/overlays")
@@ -102,73 +107,51 @@ def test_toggle_hunt_visibility(page: Page, base_url: str):
     assert entry is not None and entry["visible"] is False
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_element_toggle_odds(page: Page, base_url: str):
-    overlays = page.request.get(f"{base_url}/api/overlays").json()
-    overlay = overlays[0]
+    overlay = _create_overlay(page, base_url, name="test-odds")
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.get_by_text(overlay["name"]).first.click()
+    page.locator(f"[data-overlay-id='{overlay['id']}'] div.cursor-pointer").click()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
         and r.request.method == "PUT"
     ):
-        page.locator(".bg-bg-card").filter(has_text=overlay["name"]).locator(
-            "label"
-        ).filter(has_text="Odds").locator("input[type='checkbox']").click()
+        page.locator(
+            f"[data-overlay-id='{overlay['id']}'] [data-testid='toggle-odds'] input[type='checkbox']"
+        ).click()
 
     resp = page.request.get(f"{base_url}/api/overlays")
     updated = next(o for o in resp.json() if o["id"] == overlay["id"])
     assert updated["elements"]["odds"] is True
 
-    # Restore
-    with page.expect_response(
-        lambda r: f"/api/overlays/{overlay['id']}" in r.url
-        and r.request.method == "PUT"
-    ):
-        page.locator(".bg-bg-card").filter(has_text=overlay["name"]).locator(
-            "label"
-        ).filter(has_text="Odds").locator("input[type='checkbox']").click()
-    resp = page.request.get(f"{base_url}/api/overlays")
-    updated = next(o for o in resp.json() if o["id"] == overlay["id"])
-    assert updated["elements"]["odds"] is False
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_element_toggle_sprite(page: Page, base_url: str):
-    overlays = page.request.get(f"{base_url}/api/overlays").json()
-    overlay = overlays[0]
+    overlay = _create_overlay(page, base_url, name="test-sprite")
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.get_by_text(overlay["name"]).first.click()
+    page.locator(f"[data-overlay-id='{overlay['id']}'] div.cursor-pointer").click()
 
     with page.expect_response(
         lambda r: f"/api/overlays/{overlay['id']}" in r.url
         and r.request.method == "PUT"
     ):
-        page.locator("label").filter(has_text="Sprite").locator(
-            "input[type='checkbox']"
+        page.locator(
+            f"[data-overlay-id='{overlay['id']}'] [data-testid='toggle-sprite'] input[type='checkbox']"
         ).click()
 
     resp = page.request.get(f"{base_url}/api/overlays")
     updated = next(o for o in resp.json() if o["id"] == overlay["id"])
     assert updated["elements"]["sprite"] is False
 
-    # Restore
-    with page.expect_response(
-        lambda r: f"/api/overlays/{overlay['id']}" in r.url
-        and r.request.method == "PUT"
-    ):
-        page.locator("label").filter(has_text="Sprite").locator(
-            "input[type='checkbox']"
-        ).click()
-
-    resp = page.request.get(f"{base_url}/api/overlays")
-    updated = next(o for o in resp.json() if o["id"] == overlay["id"])
-    assert updated["elements"]["sprite"] is True
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_overlay_persistence(page: Page, base_url: str):
@@ -187,16 +170,18 @@ def test_overlay_persistence(page: Page, base_url: str):
 
 def test_copy_overlay_url(page: Page, context, base_url: str):
     context.grant_permissions(["clipboard-read", "clipboard-write"])
-    overlays = page.request.get(f"{base_url}/api/overlays").json()
-    overlay = overlays[0]
+    overlay = _create_overlay(page, base_url, name="test-copy-url")
 
     page.goto(base_url)
     page.get_by_text("Overlays", exact=True).click()
-    page.wait_for_selector("button[title='Copy overlay URL']")
-    page.locator("button[title='Copy overlay URL']").first.click()
+    page.locator(
+        f"[data-overlay-id='{overlay['id']}'] button[title='Copy overlay URL']"
+    ).click()
 
     clipboard_text = page.evaluate("async () => await navigator.clipboard.readText()")
     assert f"/overlay/{overlay['name']}-hunt" in clipboard_text
+
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_new_hunt_not_added_to_any_overlays(page: Page, base_url: str):

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -8,8 +8,10 @@ def test_settings_panel_opens(page: Page, base_url: str):
     page.get_by_role("button", name="Settings").click()
     expect(page.get_by_text("When closing the window")).to_be_visible()
     expect(page.get_by_text("When marking a hunt as found")).to_be_visible()
-    expect(page.locator("input[name='close_behavior']").first).to_be_visible()
-    expect(page.locator("input[name='mark_found_behavior']").first).to_be_visible()
+    expect(page.locator("input[name='close_behavior'][value='ask']")).to_be_visible()
+    expect(
+        page.locator("input[name='mark_found_behavior'][value='ask']")
+    ).to_be_visible()
 
 
 def test_settings_close_behavior_saved(page: Page, base_url: str):

--- a/tests/e2e/test_stats.py
+++ b/tests/e2e/test_stats.py
@@ -125,9 +125,11 @@ def test_stats_ui(page: Page, base_url: str):
     page.get_by_text("Statistics", exact=True).click()
 
     # Overall counts
-    expect(page.locator("#stats-overall .text-3xl.text-gold").first).to_have_text("2")
     expect(
-        page.locator("#stats-overall .text-3xl.text-primary-light").first
+        page.locator("#stats-overall [data-testid='completed-count']").first
+    ).to_have_text("2")
+    expect(
+        page.locator("#stats-overall [data-testid='active-count']").first
     ).to_have_text("2")
 
     # By Game - Red / Blue

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -46,7 +46,7 @@ def test_increment_decrement(page: Page, base_url: str):
     with page.expect_response(
         lambda r: "/api/hunts/" in r.url and r.request.method == "POST"
     ):
-        page.get_by_role("button", name="+", exact=True).first.click()
+        page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Increment']").click()
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])
     assert h["count"] == 1
@@ -54,7 +54,7 @@ def test_increment_decrement(page: Page, base_url: str):
     with page.expect_response(
         lambda r: "/api/hunts/" in r.url and r.request.method == "POST"
     ):
-        page.get_by_role("button", name="-", exact=True).first.click()
+        page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Decrement']").click()
     resp = page.request.get(f"{base_url}/api/hunts")
     h = next(h for h in resp.json() if h["id"] == hunt["id"])
     assert h["count"] == 0
@@ -67,7 +67,7 @@ def test_mark_as_found(page: Page, base_url: str):
     page.goto(base_url)
     expect(page.get_by_text("Rattata", exact=True).first).to_be_visible()
 
-    page.locator("button[title='Mark as Found']").click()
+    page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Mark as Found']").click()
     expect(
         page.get_by_placeholder("How did you find it? Any thoughts...")
     ).to_be_visible()
@@ -80,8 +80,15 @@ def test_mark_as_found(page: Page, base_url: str):
 
 
 def test_overlay_renders(page: Page, base_url: str):
-    page.goto(f"{base_url}/overlay/main")
+    overlay = page.request.post(
+        f"{base_url}/api/overlays",
+        data=json.dumps({"name": "test-render"}),
+        headers={"Content-Type": "application/json"},
+    ).json()
+    page.goto(f"{base_url}/overlay/{overlay['name']}-hunt")
     expect(page.locator("#hunts")).to_be_attached()
+
+    page.request.delete(f"{base_url}/api/overlays/{overlay['id']}")
 
 
 def test_api_games(page: Page, base_url: str):

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -30,13 +30,17 @@ def test_control_panel_loads(page: Page, base_url: str):
 def test_add_hunt(page: Page, base_url: str):
     page.goto(base_url)
     page.get_by_placeholder("Search Pokemon...").fill("pikachu")
-    page.get_by_role("button", name="Add Hunt").click()
-    expect(page.get_by_text("Pikachu", exact=True).first).to_be_visible(timeout=15000)
 
-    resp = page.request.get(f"{base_url}/api/hunts")
-    pikachu = next((h for h in resp.json() if h["pokemon"] == "pikachu"), None)
-    if pikachu:
-        page.request.delete(f"{base_url}/api/hunts/{pikachu['id']}")
+    with page.expect_response(
+        lambda r: "/api/hunts" in r.url and r.request.method == "POST"
+    ) as response_info:
+        page.get_by_role("button", name="Add Hunt").click()
+
+    pikachu = response_info.value.json()
+    expect(page.locator(f"[data-hunt-id='{pikachu['id']}']")).to_be_visible(
+        timeout=15000
+    )
+    page.request.delete(f"{base_url}/api/hunts/{pikachu['id']}")
 
 
 def test_increment_decrement(page: Page, base_url: str):
@@ -65,16 +69,16 @@ def test_increment_decrement(page: Page, base_url: str):
 def test_mark_as_found(page: Page, base_url: str):
     hunt = _create_hunt(page, base_url)
     page.goto(base_url)
-    expect(page.get_by_text("Rattata", exact=True).first).to_be_visible()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible()
 
     page.locator(f"[data-hunt-id='{hunt['id']}'] button[title='Mark as Found']").click()
     expect(
         page.get_by_placeholder("How did you find it? Any thoughts...")
     ).to_be_visible()
-    page.get_by_role("button", name="Mark as Found").last.click()
+    page.locator("[data-testid='confirm-mark-found']").click()
 
     page.get_by_text("History", exact=True).click()
-    expect(page.get_by_text("Rattata", exact=True).first).to_be_visible()
+    expect(page.locator(f"[data-hunt-id='{hunt['id']}']")).to_be_visible()
 
     page.request.delete(f"{base_url}/api/hunts/{hunt['id']}")
 

--- a/tests/test_hunts.py
+++ b/tests/test_hunts.py
@@ -169,3 +169,55 @@ def test_milestone_disabled_in_settings(client, hunt, monkeypatch):
     monkeypatch.setattr(app_module, "broadcast_milestone", lambda h: fired.append(h))
     client.post(f"/api/hunts/{hunt['id']}/increment")
     assert len(fired) == 0
+
+
+def test_add_hunt_missing_pokemon(client):
+    r = client.post(
+        "/api/hunts", json={"displayName": "Pikachu", "spriteUrl": None, "game": None}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "pokemon required"
+
+
+def test_add_hunt_missing_display_name(client):
+    r = client.post(
+        "/api/hunts", json={"pokemon": "pikachu", "spriteUrl": None, "game": None}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "displayName required"
+
+
+def test_update_hunt_invalid_count(client, hunt):
+    r = client.put(f"/api/hunts/{hunt['id']}", json={"count": "abc"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "count must be a number"
+
+
+def test_update_hunt_invalid_encounter_rate(client, hunt):
+    r = client.put(f"/api/hunts/{hunt['id']}", json={"encounterRate": "def"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "encounterRate must be a positive integer or null"
+
+
+def test_update_hunt_negative_encounter_rate(client, hunt):
+    r = client.put(f"/api/hunts/{hunt['id']}", json={"encounterRate": -1})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "encounterRate must be a positive integer or null"
+
+
+def test_update_hunt_empty_display_name(client, hunt):
+    r = client.put(f"/api/hunts/{hunt['id']}", json={"displayName": " "})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "displayName must be a non-empty string"
+
+
+def test_update_hunt_invalid_game_type(client, hunt):
+    r = client.put(f"/api/hunts/{hunt['id']}", json={"game": 123})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "game must be a string or null"
+
+
+def test_update_hunt_invalid_notes_type(client, hunt):
+    r = client.put(f"/api/hunts/{hunt['id']}", json={"notes": 123})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "notes must be a string or null"

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -170,7 +170,9 @@ def test_update_stats_overlay_game(client):
 
 def test_migrate_overlays_adds_type(client):
     # Create an overlay with no type direcly in store
-    import store, json
+    import json
+
+    import store
     from app import migrate_overlays
 
     overlay = {
@@ -295,3 +297,9 @@ def test_update_overlay_game_invalid_type(client, overlay):
     r = client.put(f"/api/overlays/{overlay['id']}", json={"game": 123})
     assert r.status_code == 400
     assert r.get_json()["error"] == "game must be a string or null"
+
+
+def test_new_overlay_starts_with_empty_hunts(client, hunt):
+    r = client.post("/api/overlays", json={"name": "new-overlay"})
+    assert r.status_code == 201
+    assert r.get_json()["hunts"] == []

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -194,3 +194,104 @@ def test_can_delete_last_overlay(client, overlay):
 def test_overlay_bare_path_not_found(client):
     r = client.get("/overlay")
     assert r.status_code == 404
+
+
+def test_update_overlay_empty_name(client, overlay):
+    r = client.put(f"/api/overlays/{overlay['id']}", json={"name": "  "})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "name is required"
+
+
+def test_update_overlay_elements_not_dict(client, overlay):
+    r = client.put(f"/api/overlays/{overlay['id']}", json={"elements": "bad"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "elements must be an object"
+
+
+def test_update_hunt_overlay_elements_missing_key(client, overlay):
+    r = client.put(
+        f"/api/overlays/{overlay['id']}",
+        json={"elements": {"sprite": True, "name": True, "count": True}},
+    )
+    assert r.status_code == 400
+    assert (
+        r.get_json()["error"]
+        == "hunt overlay elements must contain exactly: ['count', 'name', 'odds', 'sprite']"
+    )
+
+
+def test_update_hunt_overlay_elements_extra_key(client, overlay):
+    r = client.put(
+        f"/api/overlays/{overlay['id']}",
+        json={
+            "elements": {
+                "sprite": True,
+                "name": True,
+                "count": True,
+                "odds": False,
+                "extra": True,
+            }
+        },
+    )
+    assert r.status_code == 400
+    assert (
+        r.get_json()["error"]
+        == "hunt overlay elements must contain exactly: ['count', 'name', 'odds', 'sprite']"
+    )
+
+
+def test_update_hunt_overlay_elements_wrong_type(client, overlay):
+    r = client.put(
+        f"/api/overlays/{overlay['id']}",
+        json={"elements": {"sprite": True, "name": True, "count": True, "odds": "yes"}},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "hunt overlay elements must all be booleans"
+
+
+def test_update_stats_overlay_total_completed_wrong_type(client):
+    o = client.post(
+        "/api/overlays", json={"name": "stats-val", "type": "stats"}
+    ).get_json()
+    r = client.put(
+        f"/api/overlays/{o['id']}",
+        json={"elements": {"totalCompleted": "yes", "breakdown": "completed"}},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "totalCompleted must be a boolean"
+
+
+def test_update_stats_overlay_breakdown_invalid_value(client):
+    o = client.post(
+        "/api/overlays", json={"name": "stats-val2", "type": "stats"}
+    ).get_json()
+    r = client.put(
+        f"/api/overlays/{o['id']}",
+        json={"elements": {"totalCompleted": True, "breakdown": "invalid"}},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "breakdown must be 'completed', 'active', or null"
+
+
+def test_update_overlay_hunts_not_a_list(client, overlay):
+    r = client.put(f"/api/overlays/{overlay['id']}", json={"hunts": "bad"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "hunts must be a list"
+
+
+def test_update_overlay_hunts_invalid_entry(client, overlay):
+    r = client.put(
+        f"/api/overlays/{overlay['id']}",
+        json={"hunts": [{"huntId": "abc", "visible": "yes"}]},
+    )
+    assert r.status_code == 400
+    assert (
+        r.get_json()["error"]
+        == "each hunt entry must have huntId (string) and visible (boolean)"
+    )
+
+
+def test_update_overlay_game_invalid_type(client, overlay):
+    r = client.put(f"/api/overlays/{overlay['id']}", json={"game": 123})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "game must be a string or null"

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -111,11 +111,6 @@ def test_overlay_route_hunt_suffix(client, overlay):
     assert r.status_code == 200
 
 
-def test_overlay_route_backwards_compat(client, overlay):
-    r = client.get(f"/overlay/{overlay['name']}")
-    assert r.status_code == 200
-
-
 def test_overlay_route_stats_suffix(client):
     o = client.post(
         "/api/overlays", json={"name": "mystats", "type": "stats"}
@@ -194,3 +189,8 @@ def test_can_delete_last_overlay(client, overlay):
     r = client.delete(f"/api/overlays/{overlay['id']}")
     assert r.status_code == 204
     assert client.get("/api/overlays").get_json() == []
+
+
+def test_overlay_bare_path_not_found(client):
+    r = client.get("/overlay")
+    assert r.status_code == 404

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,3 +40,23 @@ def test_update_milestone_alerts(client):
     r = client.put("/api/settings", json={"milestone_alerts": False})
     assert r.status_code == 200
     assert r.get_json()["milestone_alerts"] is False
+
+
+def test_update_settings_invalid_close_behavior(client):
+    r = client.put("/api/settings", json={"close_behavior": "explode"})
+    assert r.status_code == 400
+    assert (
+        r.get_json()["error"] == "close_behavior must be 'ask', 'minimize', or 'quit'"
+    )
+
+
+def test_update_settings_invalid_mark_found_behavior(client):
+    r = client.put("/api/settings", json={"mark_found_behavior": "always"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "mark_found_behavior must be 'ask' or 'never'"
+
+
+def test_update_settings_invalid_milestone_alerts(client):
+    r = client.put("/api/settings", json={"milestone_alerts": "yes"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "milestone_alerts must be a boolean"


### PR DESCRIPTION
## Summary
- Adds overlay picker to the Add Hunt form - a popover with checkboxes to assign the new hunt to one or more overlays at creation time
- Includes "Select All" and inline "+ New Overlay" creation that auto-selects the created overlay
- Fixes `add_overlay()` incorrectly auto-populating all active hunts into new overlays
- Fixes overflow clipping on the new overlay name input inside the picker popover

## Test plan
- [x] E2E: `test_add_hunt_assigns_to_selected_overlay` — new hunt appears in selected overlay
- [x] E2E: `test_add_hunt_select_all_overlays` — new hunt appears in all overlays
- [x] E2E: `test_add_hunt_creates_overlay_from_form` — inline new overlay creation auto-assigns
- [x] Unit: `test_new_overlay_starts_with_empty_hunts` — regression guard for auto-populate fix

Closes Issue #58